### PR TITLE
fix Build-PSBuildModule by adding param ModuleManifestPath

### DIFF
--- a/PowerShellBuild/Public/Build-PSBuildModule.ps1
+++ b/PowerShellBuild/Public/Build-PSBuildModule.ps1
@@ -11,6 +11,8 @@ function Build-PSBuildModule {
         Destination path to write "built" module to.
     .PARAMETER ModuleName
         The name of the module.
+    .PARAMETER ModuleManifestPath
+        The path of the module manifest.
     .PARAMETER Compile
         Switch to indicate if separete function files should be concatenated into monolithic .PSM1 file.
     .PARAMETER ReadMePath
@@ -42,6 +44,8 @@ function Build-PSBuildModule {
 
         [parameter(Mandatory)]
         [string]$ModuleName,
+
+        [string]$ModuleManifestPath,
 
         [switch]$Compile,
 
@@ -93,7 +97,11 @@ function Build-PSBuildModule {
     # Export public functions in manifest if there are any public functions
     $publicFunctions = Get-ChildItem $Path/Public/*.ps1 -Recurse -ErrorAction SilentlyContinue
     if ($publicFunctions) {
-        $outputManifest = Join-Path -Path $DestinationPath -ChildPath "$ModuleName.psd1"
+        if (Test-Path -Path $ModuleManifestPath) {
+            $outputManifest = $ModuleManifestPath
+        } else {
+            $outputManifest = Join-Path -Path $DestinationPath -ChildPath "$ModuleName.psd1"
+        }
         Update-Metadata -Path $OutputManifest -PropertyName FunctionsToExport -Value $publicFunctions.BaseName
     }
 }


### PR DESCRIPTION
## Description
Adding a param for ModuleManifestPath. It tests the path, and if not valid, uses the old method.

## Related Issue
fixes #8 

## How Has This Been Tested?
My build now works and Pester is passing

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [/] My change requires a change to the documentation.
- [/] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [/] I have added tests to cover my changes.
- [X] All new and existing tests passed.
