### PR TITLE
Remove filter parameter and add filter to path

### DIFF
--- a/PowerShellBuild/Public/Build-PSBuildModule.ps1
+++ b/PowerShellBuild/Public/Build-PSBuildModule.ps1
@@ -72,7 +72,7 @@ function Build-PSBuildModule {
     # Copy source files to destination and optionally combine *.ps1 files into the PSM1
     if ($Compile.IsPresent) {
         $rootModule = Join-Path -Path $DestinationPath -ChildPath "$ModuleName.psm1"
-        $allScripts = Get-ChildItem -Path $Path -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue
+        $allScripts = Get-ChildItem -Path (Join-Path -Path $Path -ChildPath '*.ps1') -Recurse -ErrorAction SilentlyContinue
         $allScripts | ForEach-Object {
             $srcFile = Resolve-Path $_.FullName -Relative
             Write-Verbose "Adding $srcFile to PSM1"


### PR DESCRIPTION
Using the `-filter *.ps1` parameter actually pulls in `*.ps1*` files in Windows PowerShell (note that this is NOT the case with PowerShell Core). A discussion around the idiosyncrasies of the parameter is [here](https://stackoverflow.com/questions/12913734/powershell-get-childitem-filter-operates-differently-to-where-clause-with-same)

## Description
I removed the `-Filter` parameter and instead add the filter onto the path. This works in both Windows PowerShell and PowerShell Core.

## Related Issue
https://github.com/psake/PowerShellBuild/issues/13

## Motivation and Context
This fixes the issue where you have `*.ps1xml` files in your source folder / subfolder. It ensure that only `*.ps1` script files are included in the module.

## How Has This Been Tested?
I ran a normal build script which had a *.ps1xml file in the source folder and it was not included in the script module.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
