### PR TITLE
(GH-18) Explicitly set the BHBuildOutput variable

### DIFF
--- a/PowerShellBuild/Public/Initialize-PSBuild.ps1
+++ b/PowerShellBuild/Public/Initialize-PSBuild.ps1
@@ -4,6 +4,8 @@ function Initialize-PSBuild {
         Initializes BuildHelpers to populate build environment variables.
     .DESCRIPTION
         Initializes BuildHelpers to populate build environment variables.
+    .PARAMETER BuildEnvironment
+        Contains the PowerShellBuild settings (known as $PSBPreference).
     .PARAMETER UseBuildHelpers
         Use BuildHelpers module to popular common environment variables based on current build system context.
     .EXAMPLE
@@ -13,10 +15,17 @@ function Initialize-PSBuild {
     #>
     [cmdletbinding()]
     param(
+        [Parameter(Mandatory)]
+        [Hashtable]
+        $BuildEnvironment,
+
         [switch]$UseBuildHelpers
     )
 
-    Set-BuildEnvironment -Force
+    $params = @{
+        BuildOutput = $BuildEnvironment.Build.ModuleOutDir
+    }
+    Set-BuildEnvironment @params -Force
 
     Write-Host 'Build System Details:' -ForegroundColor Yellow
     $psVersion          = $PSVersionTable.PSVersion.ToString()

--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -16,7 +16,7 @@ FormatTaskName {
 # Task default -depends Test
 
 task Init {
-    Initialize-PSBuild -UseBuildHelpers
+    Initialize-PSBuild -UseBuildHelpers -BuildEnvironment $PSBPreference
 } -description 'Initialize build environment variables'
 
 task Clean -depends Init {


### PR DESCRIPTION
## Description
Explicitly set the `BHBuildOutput` variable.

## Related Issue
#18 

## Motivation and Context
This allows the environment variable to be used outside of Invoke-Build (I am using it inside Pester tests for example).

## How Has This Been Tested?
This has only been tested in an Invoke-Build environment. But the tasks that have been amended are obviously for psake anyway,

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
