### PR TITLE
Change path case for use under Core on Linux

### DIFF
--- a/PowerShellBuild/PowerShellBuild.psm1
+++ b/PowerShellBuild/PowerShellBuild.psm1
@@ -2,7 +2,7 @@
 Set-BuildEnvironment -Force
 
 # Dot source public functions
-$public  = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'public/*.ps1')  -Recurse -ErrorAction Stop)
+$public  = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Public/*.ps1')  -Recurse -ErrorAction Stop)
 foreach ($import in $public) {
     try {
         . $import.FullName


### PR DESCRIPTION
## Description
The source folder is called 'Path' but the module script uses 'path'. The case matters on Linux.
 
The change simply changes the path to the correct case - Windows won't care what the case is but Linux does.
## Related Issue
Related issue: #22

## Motivation and Context
Allows the module to be imported under Core on Linux.

## How Has This Been Tested?
The path case was changed and the module imported as normal.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.