### PR TITLE
Remove *.psm1 from file copy list

### DIFF
--- a/PowerShellBuild/Public/Build-PSBuildModule.ps1
+++ b/PowerShellBuild/Public/Build-PSBuildModule.ps1
@@ -57,13 +57,13 @@ function Build-PSBuildModule {
     }
 
     # Copy "non-processed files"
-    Get-ChildItem -Path $Path -Include '*.psm1', '*.psd1', '*.ps1xml' -Depth 1 | Copy-Item -Destination $DestinationPath -Force
+    Get-ChildItem -Path $Path -Include '*.psd1', '*.ps1xml' -Depth 1 | Copy-Item -Destination $DestinationPath -Force
 
     # Copy README as about_<modulename>.help.txt
     if (-not [string]::IsNullOrEmpty($ReadMePath)) {
         $culturePath = Join-Path -Path $DestinationPath -ChildPath $Culture
         $aboutModulePath = Join-Path -Path $culturePath -ChildPath "about_$($ModuleName).help.txt"
-        if(-not (Test-Path $culturePath -PathType Container)) {
+        if (-not (Test-Path $culturePath -PathType Container)) {
             New-Item $culturePath -Type Directory -Force > $null
             Copy-Item -LiteralPath $ReadMePath -Destination $aboutModulePath -Force
         }
@@ -78,7 +78,7 @@ function Build-PSBuildModule {
             Write-Verbose "Adding $srcFile to PSM1"
             Get-Content $srcFile
         } | Add-Content -Path $rootModule -Encoding utf8
-    } else{
+    } else {
         $copyParams = @{
             Path        = (Join-Path -Path $Path -ChildPath '*')
             Destination = $DestinationPath


### PR DESCRIPTION
Remove *.psm1 pattern from list of files to copy to output directory

## Description
When using CompileModule flag the original psm1 need not be copied from the source directory
because it is created by appending all *.ps1 files into a single file.

Including the original psm1 file in patterns to copy results in final psm1 file having original dot-sourcing code which isn't needed.


Change was to remove "*.psm1" pattern from list of those to be copied.

If not using CompileModule flag, the psm1 file is copied along with all other files in existing ELSE block

## Related Issue
This PR is related to issue #25 

## Motivation and Context
Change results in correct PSM1 file being created for both modes of Module processing ( CompileModule = $true or $false )

## How Has This Been Tested?
Minimally.

Testing involved using sample small module project included in boilerplate project created when using Stucco + Plaster.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
