### PR TITLE
Add PSM1 Module and Script Header / Footer

### DIFF
--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -25,12 +25,12 @@ task Clean -depends Init {
 
 task StageFiles -depends Clean {
     $buildParams = @{
-        Path               = $PSBPreference.General.SrcRootDir
-        ModuleName         = $PSBPreference.General.ModuleName
-        DestinationPath    = $PSBPreference.Build.ModuleOutDir
-        Exclude            = $PSBPreference.Build.Exclude
-        Compile            = $PSBPreference.Build.CompileModule
-        Culture            = $PSBPreference.Help.DefaultLocale
+        Path                = $PSBPreference.General.SrcRootDir
+        ModuleName          = $PSBPreference.General.ModuleName
+        DestinationPath     = $PSBPreference.Build.ModuleOutDir
+        Exclude             = $PSBPreference.Build.Exclude
+        Compile             = $PSBPreference.Build.CompileModule
+        Culture             = $PSBPreference.Help.DefaultLocale
     }
 
     if ($PSBPreference.Help.ConvertReadMeToAboutHelp) {
@@ -40,6 +40,14 @@ task StageFiles -depends Clean {
             $buildParams.ReadMePath = $readMePath
         }
     }
+
+    # only add these configuration values to the build parameters if they have been been set
+    'CompileHeader', 'CompileFooter', 'CompileScriptHeader', 'CompileScriptFooter' | ForEach-Object {
+        if ($PSBPreference.Build.Keys -contains $_) {
+            $buildParams.$_ = $PSBPreference.Build.$_
+        }
+    }
+
     Build-PSBuildModule @buildParams
 } -description 'Builds module based on source directory'
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ You can override these in either psake or Invoke-Build to match your environment
 | $PSBPreference.Build.Dependencies | 'StageFiles, 'BuildHelp' | Default task dependencies for the `Build` task
 | $PSBPreference.Build.ModuleOutDir | $outDir/$moduleName/$moduleVersion | Module output directory
 | $PSBPreference.Build.CompileModule | $false | Controls whether to "compile" module into single PSM1 or not
+| $PSBPreference.Build.CompileHeader | $false | String that appears at the top of your compiled PSM1 file
+| $PSBPreference.Build.CompileFooter | $false | String that appears at the bottom of your compiled PSM1 file
+| $PSBPreference.Build.CompileScriptHeader | $false | String that appears in your compiled PSM1 file before each added script
+| $PSBPreference.Build.CompileScriptFooter | $false | String that appears in your compiled PSM1 file after each added script
 | $PSBPreference.Build.Exclude | <empty> | Array of files to exclude when building module
 | $PSBPreference.Test.Enabled | $true | Enable/disable Pester tests
 | $PSBPreference.Test.RootDir | $projectRoot/tests | Directory containing Pester tests


### PR DESCRIPTION
Allows header and footers for the PSM1 file.

## Description
Allows a header and footer to be added to:

* The PSM1 script module itself
* Before and after each added script to the compiled PSM1 file

Add's four new configuration variables to allow this:

* $PSBPreference.Build.CompileHeader
* $PSBPreference.Build.CompileFooter
* $PSBPreference.Build.CompileScriptHeader
* $PSBPreference.Build.CompileScriptFooter

## Related Issue
#15 and #25 

## Motivation and Context
Allows you to add more code to the PSM1 file than just the compield scripts.

## How Has This Been Tested?
I've tested this in my own project by adding text to the configuration variables and watching the output.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
