### PR TITLE
Allow using Credential and ApiKey when publishing a module

### DIFF
--- a/PowerShellBuild/Public/Publish-PSBuildModule.ps1
+++ b/PowerShellBuild/Public/Publish-PSBuildModule.ps1
@@ -10,18 +10,22 @@ function Publish-PSBuildModule {
         The version of the module to publish.
     .PARAMETER Repository
         The PowerShell repository name to publish to.
-    .PARAMETER ApiKey
+    .PARAMETER NuGetApiKey
         The API key to use to authenticate to the PowerShell repository with.
     .PARAMETER Credential
         The credential to use to authenticate to the PowerShell repository with.
     .EXAMPLE
-        PS> Publish-PSBuildModule -Path .\Output\0.1.0\MyModule -Version 0.1.0 -Repository PSGallery -ApiKey 12345
+        PS> Publish-PSBuildModule -Path .\Output\0.1.0\MyModule -Version 0.1.0 -Repository PSGallery -NuGetApiKey 12345
 
         Publish version 0.1.0 of the module at path .\Output\0.1.0\MyModule to the PSGallery repository using an API key.
     .EXAMPLE
         PS> Publish-PSBuildModule -Path .\Output\0.1.0\MyModule -Version 0.1.0 -Repository PSGallery -Credential $myCred
 
         Publish version 0.1.0 of the module at path .\Output\0.1.0\MyModule to the PSGallery repository using a PowerShell credential.
+    .EXAMPLE
+        PS> Publish-PSBuildModule -Path .\Output\0.1.0\MyModule -Version 0.1.0 -Repository PSGallery -NuGetApiKey 12345 -Credential $myCred
+
+        Publish version 0.1.0 of the module at path .\Output\0.1.0\MyModule to the PSGallery repository using an API key and a PowerShell credential.
     #>
     [cmdletbinding(DefaultParameterSetName = 'ApiKey')]
     param(
@@ -43,10 +47,9 @@ function Publish-PSBuildModule {
         [parameter(Mandatory)]
         [string]$Repository,
 
-        [parameter(Mandatory, ParameterSetName = 'ApiKey')]
-        [string]$ApiKey,
+        [Alias('ApiKey')]
+        [string]$NuGetApiKey,
 
-        [parameter(Mandatory, ParameterSetName = 'Credential')]
         [pscredential]$Credential
     )
 
@@ -57,9 +60,12 @@ function Publish-PSBuildModule {
         Repository = $Repository
         Verbose    = $VerbosePreference
     }
-    switch ($PSCmdlet.ParameterSetName) {
-        'Credential' { $publishParams.Credential  = $Credential }
-        'ApiKey'     { $publishParams.NuGetApiKey = $ApiKey }
+
+    'NuGetApiKey', 'Credential' | ForEach-Object {
+        if ($PSBoundParameters.ContainsKey($_)) {
+            $publishParams.$_ = $PSBoundParameters.$_
+        }
     }
+
     Publish-Module @publishParams
 }

--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -153,7 +153,9 @@ task Publish -depends Test {
     }
     if ($PSBPreference.Publish.PSRepositoryApiKey) {
         $publishParams.ApiKey = $PSBPreference.Publish.PSRepositoryApiKey
-    } else {
+    }
+
+    if ($PSBPreference.Publish.PSRepositoryCredential) {
         $publishParams.Credential = $PSBPreference.Publish.PSRepositoryCredential
     }
 


### PR DESCRIPTION
Allows the use of both Credential and ApiKey to be used.

Closes #29 

## Description
Some authenticated feeds (or all the ones I've used) require both the Credential and ApiKey parameters to be used. This changes both the Publish psake task and the Publish-PSBuildModule to use either or both.

## Related Issue
#29 

## Motivation and Context
Allows publishing modules to authenticated feeds that require both a Credential and ApiKey parameter.

## How Has This Been Tested?
I have a build process I use for internal modules that this change has been tested on and it successfully publishes the module on an external feed and is able to also check that feed for dependent internal modules.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
