### PR TITLE
Add Pester output file parameters rather than replace existing parameters - Fixes #31

### DIFF
--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -52,10 +52,8 @@ function Test-PSBuildPester {
             Verbose  = $VerbosePreference
         }
         if (-not [string]::IsNullOrEmpty($OutputPath)) {
-            $pesterParams = @{
-                OutputFile   = $OutputPath
-                OutputFormat = $OutputFormat
-            }
+            $pesterParams.OutputFile   = $OutputPath
+            $pesterParams.OutputFormat = $OutputFormat
         }
 
         # To control the Pester code coverage, a boolean $CodeCoverageEnabled is used.


### PR DESCRIPTION
## Description
Fixes the issue found in #31 where the PassThru parameter was replaced by the output file parameters, causing builds to not fail when an output file is specified for use in CI pipelines.
## Related Issue
#31 

## How Has This Been Tested?

Ran through a few builds that both used an output file and no output file and behaviour was as it should be.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
