### PR TITLE
Fix default values for Compile Header / Footer in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ You can override these in either psake or Invoke-Build to match your environment
 | $PSBPreference.Build.Dependencies | 'StageFiles, 'BuildHelp' | Default task dependencies for the `Build` task
 | $PSBPreference.Build.ModuleOutDir | $outDir/$moduleName/$moduleVersion | `For internal use only. Do not overwrite. Use '$PSBPreference.Build.OutDir' to set output directory`
 | $PSBPreference.Build.CompileModule | $false | Controls whether to "compile" module into single PSM1 or not
-| $PSBPreference.Build.CompileHeader | $false | String that appears at the top of your compiled PSM1 file
-| $PSBPreference.Build.CompileFooter | $false | String that appears at the bottom of your compiled PSM1 file
-| $PSBPreference.Build.CompileScriptHeader | $false | String that appears in your compiled PSM1 file before each added script
-| $PSBPreference.Build.CompileScriptFooter | $false | String that appears in your compiled PSM1 file after each added script
+| $PSBPreference.Build.CompileHeader | <empty> | String that appears at the top of your compiled PSM1 file
+| $PSBPreference.Build.CompileFooter | <empty> | String that appears at the bottom of your compiled PSM1 file
+| $PSBPreference.Build.CompileScriptHeader | <empty> | String that appears in your compiled PSM1 file before each added script
+| $PSBPreference.Build.CompileScriptFooter | <empty> | String that appears in your compiled PSM1 file after each added script
 | $PSBPreference.Build.Exclude | <empty> | Array of files to exclude when building module
 | $PSBPreference.Test.Enabled | $true | Enable/disable Pester tests
 | $PSBPreference.Test.RootDir | $projectRoot/tests | Directory containing Pester tests


### PR DESCRIPTION
This fixes the default values that were incorectly set in #28 

* Compile Header / Footer default values are now correctly set to `<empty>`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
