### PR TITLE
Add standalone InvokeBuild tasks

### DIFF
--- a/PowerShellBuild/IB.tasks.ps1
+++ b/PowerShellBuild/IB.tasks.ps1
@@ -1,0 +1,173 @@
+Remove-Variable -Name PSBPreference -Scope Script -Force -ErrorAction Ignore
+Set-Variable -Name PSBPreference -Option ReadOnly -Scope Script -Value (. (Join-Path -Path $PSScriptRoot -ChildPath build.properties.ps1))
+
+# Synopsis: Initialize build environment variables
+task Init {
+    Initialize-PSBuild -UseBuildHelpers -BuildEnvironment $PSBPreference
+}
+
+# Synopsis: Clears module output directory
+task Clean Init, {
+    Clear-PSBuildOutputFolder -Path $PSBPreference.Build.ModuleOutDir
+}
+
+# Synopsis: Builds module based on source directory
+task StageFiles Clean, {
+    $buildParams = @{
+        Path               = $PSBPreference.General.SrcRootDir
+        ModuleName         = $PSBPreference.General.ModuleName
+        DestinationPath    = $PSBPreference.Build.ModuleOutDir
+        Exclude            = $PSBPreference.Build.Exclude
+        Compile            = $PSBPreference.Build.CompileModule
+        Culture            = $PSBPreference.Help.DefaultLocale
+    }
+
+    if ($PSBPreference.Help.ConvertReadMeToAboutHelp) {
+        $readMePath = Get-ChildItem -Path $PSBPreference.General.ProjectRoot -Include 'readme.md', 'readme.markdown', 'readme.txt' -Depth 1 |
+            Select-Object -First 1
+        if ($readMePath) {
+            $buildParams.ReadMePath = $readMePath
+        }
+    }
+
+    'CompileHeader', 'CompileFooter', 'CompileScriptHeader', 'CompileScriptFooter' | ForEach-Object {
+        if ($PSBPreference.Build.Keys -contains $_) {
+            $buildParams.$_ = $PSBPreference.Build.$_
+        }
+    }
+
+    Build-PSBuildModule @buildParams
+}
+
+# Synopsis: Builds module and generate help documentation
+Task Build $($PSBPreference.Build.Dependencies -join ", ")
+
+$analyzePreReqs = {
+    $result = $true
+    if (-not $PSBPreference.Test.ScriptAnalysis.Enabled) {
+        Write-Warning 'Script analysis is not enabled.'
+        $result = $false
+    }
+    if (-not (Get-Module -Name PSScriptAnalyzer -ListAvailable)) {
+        Write-Warning 'PSScriptAnalyzer module is not installed'
+        $result = $false
+    }
+    $result
+}
+
+# Synopsis: Execute PSScriptAnalyzer tests
+task Analyze Build, {
+    $analyzeParams = @{
+        Path              = $PSBPreference.Build.ModuleOutDir
+        SeverityThreshold = $PSBPreference.Test.ScriptAnalysis.FailBuildOnSeverityLevel
+        SettingsPath      = $PSBPreference.Test.ScriptAnalysis.SettingsPath
+    }
+    Test-PSBuildScriptAnalysis @analyzeParams
+}
+
+$pesterPreReqs = {
+    $result = $true
+    if (-not $PSBPreference.Test.Enabled) {
+        Write-Warning 'Pester testing is not enabled.'
+        $result = $false
+    }
+    if (-not (Get-Module -Name Pester -ListAvailable)) {
+        Write-Warning 'Pester module is not installed'
+        $result = $false
+    }
+    if (-not (Test-Path -Path $PSBPreference.Test.RootDir)) {
+        Write-Warning "Test directory [$($PSBPreference.Test.RootDir)] not found"
+        $result = $false
+    }
+    return $result
+}
+
+# Synopsis: Execute Pester tests
+task Pester Build, {
+    $pesterParams = @{
+        Path                  = $PSBPreference.Test.RootDir
+        ModuleName            = $PSBPreference.General.ModuleName
+        OutputPath            = $PSBPreference.Test.OutputFile
+        OutputFormat          = $PSBPreference.Test.OutputFormat
+        CodeCoverage          = $PSBPreference.Test.CodeCoverage.Enabled
+        CodeCoverageThreshold = $PSBPreference.Test.CodeCoverage.Threshold
+        CodeCoverageFiles     = $PSBPreference.Test.CodeCoverage.Files
+    }
+    Test-PSBuildPester @pesterParams
+}
+
+# Synopsis: Execute Pester and ScriptAnalyzer tests
+task Test Pester, Analyze, {
+}
+
+# Synopsis: Builds help documentation
+task BuildHelp GenerateMarkdown, GenerateMAML, {}
+
+$genMarkdownPreReqs = {
+    $result = $true
+    if (-not (Get-Module platyPS -ListAvailable)) {
+        Write-Warning "platyPS module is not installed. Skipping [$($task.name)] task."
+        $result = $false
+    }
+    $result
+}
+
+# Synopsis: Generates PlatyPS markdown files from module help
+task GenerateMarkdown StageFiles, {
+    $buildMDParams = @{
+        ModulePath = $PSBPreference.Build.ModuleOutDir
+        ModuleName = $PSBPreference.General.ModuleName
+        DocsPath   = $PSBPreference.Docs.RootDir
+        Locale     = $PSBPreference.Help.DefaultLocale
+    }
+    Build-PSBuildMarkdown @buildMDParams
+}
+
+$genHelpFilesPreReqs = {
+    $result = $true
+    if (-not (Get-Module platyPS -ListAvailable)) {
+        Write-Warning "platyPS module is not installed. Skipping [$($task.name)] task."
+        $result = $false
+    }
+    $result
+}
+
+# Synopsis: Generates MAML-based help from PlatyPS markdown files
+task GenerateMAML GenerateMarkdown, {
+    Build-PSBuildMAMLHelp -Path $PSBPreference.Docs.RootDir -DestinationPath $PSBPreference.Build.ModuleOutDir
+}
+
+$genUpdatableHelpPreReqs = {
+    $result = $true
+    if (-not (Get-Module platyPS -ListAvailable)) {
+        Write-Warning "platyPS module is not installed. Skipping [$($task.name)] task."
+        $result = $false
+    }
+    $result
+}
+
+# Synopsis: Create updatable help .cab file based on PlatyPS markdown help
+task GenerateUpdatableHelp BuildHelp, {
+    Build-PSBuildUpdatableHelp -DocsPath $PSBPreference.Docs.RootDir -OutputPath $PSBPreference.Help.UpdatableHelpOutDir
+}
+
+# Synopsis: Publish module to the defined PowerShell repository
+Task Publish Test, {
+    Assert ($PSBPreference.Publish.PSRepositoryApiKey -or $PSBPreference.Publish.PSRepositoryCredential) "API key or credential not defined to authenticate with [$($PSBPreference.Publish.PSRepository)] with."
+
+    $publishParams = @{
+        Path       = $PSBPreference.Build.ModuleOutDir
+        Version    = $PSBPreference.General.ModuleVersion
+        Repository = $PSBPreference.Publish.PSRepository
+        Verbose    = $true #$VerbosePreference
+    }
+    if ($PSBPreference.Publish.PSRepositoryApiKey) {
+        $publishParams.ApiKey = $PSBPreference.Publish.PSRepositoryApiKey
+    }
+
+    if ($PSBPreference.Publish.PSRepositoryCredential) {
+        $publishParams.Credential = $PSBPreference.Publish.PSRepositoryCredential
+    }
+
+    Publish-PSBuildModule @publishParams
+}

--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -55,10 +55,11 @@ task Build -depends Init, Clean {
     New-Item -Path $settings.ModuleOutDir -ItemType Directory -Force > $null
     Copy-Item -Path "$($settings.SUT)/*" -Destination $settings.ModuleOutDir -Recurse
 
+    # Commented out rather than removed to allow easy use in future
     #Generate Invoke-Build tasks from Psake tasks
-    $psakePath = join-path $settings.ModuleOutDir 'psakefile.ps1'
-    $ibPath = join-path $settings.ModuleOutDir 'IB.tasks.ps1'
-    & .\Build\Convert-PSAke.ps1 $psakePath | Out-File -Encoding UTF8 $ibPath
+    #$psakePath = join-path $settings.ModuleOutDir 'psakefile.ps1'
+    #$ibPath = join-path $settings.ModuleOutDir 'IB.tasks.ps1'
+    #& .\Build\Convert-PSAke.ps1 $psakePath | Out-File -Encoding UTF8 $ibPath
 }
 
 task Publish -depends Test {

--- a/tests/IBTasks.tests.ps1
+++ b/tests/IBTasks.tests.ps1
@@ -6,7 +6,7 @@ $outputModVerDir    = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleV
 $ibTasksFilePath    = Join-Path -Path $outputModVerDir -ChildPath 'IB.tasks.ps1'
 $psakeFilePath       = Join-Path -Path $outputModVerDir -ChildPath 'psakeFile.ps1'
 
-Describe 'Invoke-Build Conversion' {
+Describe 'Invoke-Build Tasks' {
     $IBTasksResult = $null
     It 'IB.tasks.ps1 exists' {
         Test-Path $IBTasksFilePath | Should Be $true


### PR DESCRIPTION
The psake to InvokeBuild conversion is problematic so a standalone InvokeBuild tasks script has been added.

## Description
* Added a standalone IB.tasks.ps1 InvokeBuild tasks script;
* Disabled the psake -> InvokeBuild tasks conversion in the build;
* Amended the InvokeBuild Pester test description;

## Related Issue
#16 

## Motivation and Context
The psake conversion is problematic. It was agreed in #16 that the InvokeBuild tasks should be standalone _for the time being_.

## How Has This Been Tested?
The InvokeBuild tasks used are the ones created by the conversion script in the last version - with a couple of fixes to the `Assert` statement in the Publish task (which did not work in InvokeBuild) and also to fix the `Build` task to allow it to use `$PSBPreference.Build.Dependencies` which didn;t work for InvokeBuild.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
