### PR TITLE
Preserve Dependency Variables (Fixes psake#16)

### DIFF
--- a/Build/Convert-PSAke.ps1
+++ b/Build/Convert-PSAke.ps1
@@ -30,6 +30,10 @@ function Convert-PsakeStatement ([Language.StatementAst]$statement) {
     $statementText = $statement.extent.text
     $psakeStatement = ($statementText | Select-String '^\w+\b').matches.value
 
+    #Escape out variables in parameters so they get passed through literally
+    #TODO: Do this with AST instead of RegEX
+    $statementText = $statementText -replace '(\$[\.\w]*)',(@("'",'$1',"'") -join $null)
+
     if ($psakeStatement -in $psakeStatements) {
         if (-not (Get-Alias "$psakeStatement" -erroraction SilentlyContinue)) {
             if (get-command "Convert-$psakeStatement" -erroraction SilentlyContinue) {


### PR DESCRIPTION
This pull request resolves the issue where the Build task shows empty dependencies, because the nature of processing was resolving the variable as empty

Fixes #16 