### PR TITLE
Remove Set-BuildEnvironment from psm1

### DIFF
--- a/PowerShellBuild/PowerShellBuild.psm1
+++ b/PowerShellBuild/PowerShellBuild.psm1
@@ -1,6 +1,3 @@
-
-Set-BuildEnvironment -Force
-
 # Dot source public functions
 $public  = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Public/*.ps1')  -Recurse -ErrorAction Stop)
 foreach ($import in $public) {


### PR DESCRIPTION
Set-BuildEnvironment runs as part of initialization, and is extraneous here. Causes additional warnings for users who may import the module outside of the intended folder, and increases load time for the module unnecessarily.
