### PR TITLE
Fix exclude files on compile

### DIFF
--- a/PowerShellBuild/Public/Build-PSBuildModule.ps1
+++ b/PowerShellBuild/Public/Build-PSBuildModule.ps1
@@ -93,6 +93,15 @@ function Build-PSBuildModule {
         }
 
         $allScripts = Get-ChildItem -Path (Join-Path -Path $Path -ChildPath '*.ps1') -Recurse -ErrorAction SilentlyContinue
+        # do this because -Exclude in Get-ChildItem is broken
+        $allScripts = $allScripts | ForEach-Object {
+            ForEach ($regex in $Exclude) {
+                if ($_ -notmatch $regex) {
+                    $_
+                }
+            }
+        }
+
         $allScripts | ForEach-Object {
             $srcFile = Resolve-Path $_.FullName -Relative
             Write-Verbose "Adding $srcFile to PSM1"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can override these in either psake or Invoke-Build to match your environment
 | $PSBPreference.Build.CompileFooter | <empty> | String that appears at the bottom of your compiled PSM1 file
 | $PSBPreference.Build.CompileScriptHeader | <empty> | String that appears in your compiled PSM1 file before each added script
 | $PSBPreference.Build.CompileScriptFooter | <empty> | String that appears in your compiled PSM1 file after each added script
-| $PSBPreference.Build.Exclude | <empty> | Array of files to exclude when building module
+| $PSBPreference.Build.Exclude | <empty> | Array of files to exclude when building module. If `$PSBPreference.Build.CompileModule` is `$true` this will be an array of regular expressions to match fiels to exclude
 | $PSBPreference.Test.Enabled | $true | Enable/disable Pester tests
 | $PSBPreference.Test.RootDir | $projectRoot/tests | Directory containing Pester tests
 | $PSBPreference.Test.OutputFile | $null | Output file path Pester will save test results to


### PR DESCRIPTION
## Description
* If `Build.CompileModule` is `$true` then `Build.Exclude` is treated as an array of regular expressions and the files found to be included into the compiled PSM1 file are matched and excluded;
* Updated the documentation to say that `Build.Exclude` is an array of regular expressions if `Build.CompileModule` is `$true`;

## Related Issue
#40 - note that I added this PR for discussion so it's clearer what I'm doing.

## Motivation and Context
Currently, if you compile the module then all PS1 files found recursively from `General.SrcRootDir` are included into the compiled PSM1 file. This is clearly not desired behaviour.

## How Has This Been Tested?
This issue was found, fixed and tested in one of my own private projects. It now has the desired behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Fixes #40 