### PR TITLE
Optionally import module prior to running Pester tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.1] - 2020-04-22
+
+### Added
+
+- Define `ModuleOutputManifest` in build properties.
+
+### Fixed
+
+- Use `ModuleOutputManifest` build property to load the recently built module before pester tests are executed. This also ensures the tests that are being run are run against the built code vs. whats in development.
+
 ## [0.5.0] - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.5.1] - 2020-04-22
-
-### Added
-
-- Define `ModuleOutputManifest` in build properties.
-
-### Fixed
-
-- Use `ModuleOutputManifest` build property to load the recently built module before pester tests are executed. This also ensures the tests that are being run are run against the built code vs. whats in development.
-
 ## [0.5.0] - Unreleased
 
 ### Added
@@ -24,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `$PSBPreference.Build.CompileFooter`
   - `$PSBPreference.Build.CompileScriptHeader`
   - `$PSBPreference.Build.CompileScriptFooter`
+
+- Add ability to import project module from output directory prior to executing Pester tests. Toggle this with `$PSBPreference.Test.ImportModule`. Defaults to `false`. (via [@joeypiccola](https://github.com/joeypiccola))
 
 ### Fixed
 

--- a/PowerShellBuild/PowerShellBuild.psd1
+++ b/PowerShellBuild/PowerShellBuild.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PowerShellBuild.psm1'
-    ModuleVersion     = '0.5.0'
+    ModuleVersion     = '0.5.1'
     GUID              = '15431eb8-be2d-4154-b8ad-4cb68a488e3d'
     Author            = 'Brandon Olin'
     CompanyName       = 'Community'

--- a/PowerShellBuild/PowerShellBuild.psd1
+++ b/PowerShellBuild/PowerShellBuild.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PowerShellBuild.psm1'
-    ModuleVersion     = '0.5.1'
+    ModuleVersion     = '0.5.0'
     GUID              = '15431eb8-be2d-4154-b8ad-4cb68a488e3d'
     Author            = 'Brandon Olin'
     CompanyName       = 'Community'

--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -38,7 +38,9 @@ function Test-PSBuildPester {
 
         [double]$CodeCoverageThreshold,
 
-        [string[]]$CodeCoverageFiles = @()
+        [string[]]$CodeCoverageFiles = @(),
+
+        [string]$ModuleOutputManifest
     )
 
     if (-not (Get-Module -Name Pester)) {
@@ -46,6 +48,11 @@ function Test-PSBuildPester {
     }
 
     try {
+        # Remove any previously imported project modules
+        Get-Module $ModuleName | Remove-Module -Force
+        # Import recently built project module from versioned output dir
+        Import-Module $ModuleOutputManifest -Force
+
         Push-Location -LiteralPath $Path
         $pesterParams = @{
             PassThru = $true

--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -18,10 +18,8 @@ function Test-PSBuildPester {
         Threshold required to pass code coverage test (.90 = 90%).
     .PARAMETER CodeCoverageFiles
         Array of files to validate code coverage for.
-    .PARAMETER ModuleOutputManifest
-        Path to the module manifest that was built in the output directory. Used to import the project module.
     .PARAMETER ImportModule
-        Import module from provided ModuleOutputManifest path.
+        Import module from OutDir prior to running Pester tests.
     .EXAMPLE
         PS> Test-PSBuildPester -Path ./tests -ModuleName Mymodule -OutputPath ./out/testResults.xml
 
@@ -44,8 +42,6 @@ function Test-PSBuildPester {
 
         [string[]]$CodeCoverageFiles = @(),
 
-        [string]$ModuleOutputManifest,
-
         [switch]$ImportModule
     )
 
@@ -55,9 +51,11 @@ function Test-PSBuildPester {
 
     try {
         if ($ImportModule) {
+            $ModuleOutputManifest = Join-Path -Path $env:BHBuildOutput -ChildPath "$($ModuleName).psd1"
+            Write-Verbose "ModuleOutputManifest: $ModuleOutputManifest"
             # Remove any previously imported project modules
             Get-Module $ModuleName | Remove-Module -Force
-            # Import recently built project module from versioned output dir
+            # Import recently built project module from BHBuildOutput
             Import-Module $ModuleOutputManifest -Force
         }
 

--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -52,7 +52,6 @@ function Test-PSBuildPester {
     try {
         if ($ImportModule) {
             $ModuleOutputManifest = Join-Path -Path $env:BHBuildOutput -ChildPath "$($ModuleName).psd1"
-            Write-Verbose "ModuleOutputManifest: $ModuleOutputManifest"
             # Remove any previously imported project modules
             Get-Module $ModuleName | Remove-Module -Force
             # Import recently built project module from BHBuildOutput

--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -19,7 +19,9 @@ function Test-PSBuildPester {
     .PARAMETER CodeCoverageFiles
         Array of files to validate code coverage for.
     .PARAMETER ModuleOutputManifest
-        Path to the module manifest that was built in the output directory. Used to load the project module.
+        Path to the module manifest that was built in the output directory. Used to import the project module.
+    .PARAMETER ImportModule
+        Import module from provided ModuleOutputManifest path.
     .EXAMPLE
         PS> Test-PSBuildPester -Path ./tests -ModuleName Mymodule -OutputPath ./out/testResults.xml
 
@@ -42,7 +44,9 @@ function Test-PSBuildPester {
 
         [string[]]$CodeCoverageFiles = @(),
 
-        [string]$ModuleOutputManifest
+        [string]$ModuleOutputManifest,
+
+        [switch]$ImportModule
     )
 
     if (-not (Get-Module -Name Pester)) {
@@ -50,10 +54,12 @@ function Test-PSBuildPester {
     }
 
     try {
-        # Remove any previously imported project modules
-        Get-Module $ModuleName | Remove-Module -Force
-        # Import recently built project module from versioned output dir
-        Import-Module $ModuleOutputManifest -Force
+        if ($ImportModule) {
+            # Remove any previously imported project modules
+            Get-Module $ModuleName | Remove-Module -Force
+            # Import recently built project module from versioned output dir
+            Import-Module $ModuleOutputManifest -Force
+        }
 
         Push-Location -LiteralPath $Path
         $pesterParams = @{

--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -18,6 +18,8 @@ function Test-PSBuildPester {
         Threshold required to pass code coverage test (.90 = 90%).
     .PARAMETER CodeCoverageFiles
         Array of files to validate code coverage for.
+    .PARAMETER ModuleOutputManifest
+        Path to the module manifest that was built in the output directory. Used to load the project module.
     .EXAMPLE
         PS> Test-PSBuildPester -Path ./tests -ModuleName Mymodule -OutputPath ./out/testResults.xml
 

--- a/PowerShellBuild/build.properties.ps1
+++ b/PowerShellBuild/build.properties.ps1
@@ -37,6 +37,9 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
 
         # List of files to exclude from output directory
         Exclude = @()
+
+        # Build output module manifest
+        ModuleOutputManifest = "$outDir/$env:BHProjectName/$moduleVersion/$env:BHProjectName.psd1"
     }
     Test = @{
         # Enable/disable Pester tests

--- a/PowerShellBuild/build.properties.ps1
+++ b/PowerShellBuild/build.properties.ps1
@@ -37,9 +37,6 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
 
         # List of files to exclude from output directory
         Exclude = @()
-
-        # Build output module manifest
-        ModuleOutputManifest = "$outDir/$env:BHProjectName/$moduleVersion/$env:BHProjectName.psd1"
     }
     Test = @{
         # Enable/disable Pester tests
@@ -71,6 +68,9 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
             # Path to the PSScriptAnalyzer settings file.
             SettingsPath = Join-Path $PSScriptRoot -ChildPath ScriptAnalyzerSettings.psd1
         }
+
+        # Build output module manifest
+        ModuleOutputManifest = "$outDir/$env:BHProjectName/$moduleVersion/$env:BHProjectName.psd1"
 
         CodeCoverage = @{
             # Enable/disable Pester code coverage reporting.

--- a/PowerShellBuild/build.properties.ps1
+++ b/PowerShellBuild/build.properties.ps1
@@ -72,6 +72,9 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
         # Build output module manifest
         ModuleOutputManifest = "$outDir/$env:BHProjectName/$moduleVersion/$env:BHProjectName.psd1"
 
+        # Import module from provided ModuleOutputManifest path.
+        ImportModule = $false
+
         CodeCoverage = @{
             # Enable/disable Pester code coverage reporting.
             Enabled = $false

--- a/PowerShellBuild/build.properties.ps1
+++ b/PowerShellBuild/build.properties.ps1
@@ -69,10 +69,7 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
             SettingsPath = Join-Path $PSScriptRoot -ChildPath ScriptAnalyzerSettings.psd1
         }
 
-        # Build output module manifest
-        ModuleOutputManifest = "$outDir/$env:BHProjectName/$moduleVersion/$env:BHProjectName.psd1"
-
-        # Import module from provided ModuleOutputManifest path.
+        # Import module from OutDir prior to running Pester tests.
         ImportModule = $false
 
         CodeCoverage = @{

--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -98,7 +98,7 @@ task Pester -depends Build -precondition $pesterPreReqs {
         OutputFormat          = $PSBPreference.Test.OutputFormat
         CodeCoverage          = $PSBPreference.Test.CodeCoverage.Enabled
         CodeCoverageThreshold = $PSBPreference.Test.CodeCoverage.Threshold
-        CodeCoverageFiles     = $PSBPreference.Test.CodeCoverage.Files
+        ModuleOutputManifest  = $PSBPreference.Build.ModuleOutputManifest
     }
     Test-PSBuildPester @pesterParams
 } -description 'Execute Pester tests'

--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -98,7 +98,7 @@ task Pester -depends Build -precondition $pesterPreReqs {
         OutputFormat          = $PSBPreference.Test.OutputFormat
         CodeCoverage          = $PSBPreference.Test.CodeCoverage.Enabled
         CodeCoverageThreshold = $PSBPreference.Test.CodeCoverage.Threshold
-        ModuleOutputManifest  = $PSBPreference.Build.ModuleOutputManifest
+        ModuleOutputManifest  = $PSBPreference.Test.ModuleOutputManifest
     }
     Test-PSBuildPester @pesterParams
 } -description 'Execute Pester tests'

--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -100,6 +100,7 @@ task Pester -depends Build -precondition $pesterPreReqs {
         CodeCoverageThreshold = $PSBPreference.Test.CodeCoverage.Threshold
         CodeCoverageFiles     = $PSBPreference.Test.CodeCoverage.Files
         ModuleOutputManifest  = $PSBPreference.Test.ModuleOutputManifest
+        ImportModule          = $PSBPreference.Test.ImportModule
     }
     Test-PSBuildPester @pesterParams
 } -description 'Execute Pester tests'

--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -98,6 +98,7 @@ task Pester -depends Build -precondition $pesterPreReqs {
         OutputFormat          = $PSBPreference.Test.OutputFormat
         CodeCoverage          = $PSBPreference.Test.CodeCoverage.Enabled
         CodeCoverageThreshold = $PSBPreference.Test.CodeCoverage.Threshold
+        CodeCoverageFiles     = $PSBPreference.Test.CodeCoverage.Files
         ModuleOutputManifest  = $PSBPreference.Test.ModuleOutputManifest
     }
     Test-PSBuildPester @pesterParams

--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -99,7 +99,6 @@ task Pester -depends Build -precondition $pesterPreReqs {
         CodeCoverage          = $PSBPreference.Test.CodeCoverage.Enabled
         CodeCoverageThreshold = $PSBPreference.Test.CodeCoverage.Threshold
         CodeCoverageFiles     = $PSBPreference.Test.CodeCoverage.Files
-        ModuleOutputManifest  = $PSBPreference.Test.ModuleOutputManifest
         ImportModule          = $PSBPreference.Test.ImportModule
     }
     Test-PSBuildPester @pesterParams

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can override these in either psake or Invoke-Build to match your environment
 | $PSBPreference.Test.CodeCoverage.Enabled | $false | Enable/disable Pester code coverage reporting
 | $PSBPreference.Test.CodeCoverage.Threshold | .75 | Fail Pester code coverage test if below this threshold
 | $PSBPreference.Test.CodeCoverage.Files | *.ps1, *.psm1 | Files to perform code coverage analysis on
+| $PSBPreference.Test.ImportModule | $false | Import module from output directory prior to running Pester tests
 | $PSBPreference.Help.UpdatableHelpOutDir | $OutDir/UpdatableHelp | Output directory to store update module help (CAB)
 | $PSBPreference.Help.DefaultLocale | (Get-UICulture).Name | Default locale used for help generation
 | $PSBPreference.Help.ConvertReadMeToAboutHelp | $false | Convert project readme into the module about file


### PR DESCRIPTION
## Description
This PR adds the property `ImportModule` to the `test` build property hash. This property is passed to `Test-PSBuildPester` so that Pester can optionally import the module from the specified OutDir. This _feature_ can be optionally used by specifying `$PSBPreference.Test.ImportModule = $true`. 

## Related Issue
#45 

## Motivation and Context
Optionally import module prior to running Pesters tests.
1. Simplify `.tests.ps1` files removing redundant code to import the project module.
2. Ensure the module imported for testing is the one build in the `OurDir`.

## How Has This Been Tested?
1. Built module locally. Took contents of output directory and placed them in my module path under `PowerShellBuild/0.5.0` directory. 
2. Created vanilla module via the Plaster Stucco template `v0.2.0`
3. Modified `psakeFile.ps1` file to use `task Test -FromModule PowerShellBuild -Version '0.5.0'`.
4. run `build.ps1 -bootstrap`
5. run `build.ps1 -task pester`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fixes #45 