### PR TITLE
Codecoverage param update

### DIFF
--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -18,6 +18,10 @@ function Test-PSBuildPester {
         Threshold required to pass code coverage test (.90 = 90%).
     .PARAMETER CodeCoverageFiles
         Array of files to validate code coverage for.
+    .PARAMETER CodeCoverageOutputFile
+        Output path to store Pester code coverage results to..
+    .PARAMETER CodeCoverageOutputFileFormat
+        code coverage result output format (JoCoCo).
     .PARAMETER ImportModule
         Import module from OutDir prior to running Pester tests.
     .EXAMPLE
@@ -41,6 +45,10 @@ function Test-PSBuildPester {
         [double]$CodeCoverageThreshold,
 
         [string[]]$CodeCoverageFiles = @(),
+
+        [string]$CodeCoverageOutputFile,
+
+        [string]$CodeCoverageOutputFileFormat,
 
         [switch]$ImportModule
     )
@@ -71,6 +79,8 @@ function Test-PSBuildPester {
         # To control the Pester code coverage, a boolean $CodeCoverageEnabled is used.
         if ($CodeCoverage.IsPresent) {
             $pesterParams.CodeCoverage = $CodeCoverageFiles
+            $pesterParams.CodeCoverageOutputFile = $CodeCoverageOutputFile
+            $pesterParams.CodeCoverageOutputFileFormat = $CodeCoverageOutputFileFormat
         }
 
         $testResult = Invoke-Pester @pesterParams

--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -79,6 +79,10 @@ function Test-PSBuildPester {
         # To control the Pester code coverage, a boolean $CodeCoverageEnabled is used.
         if ($CodeCoverage.IsPresent) {
             $pesterParams.CodeCoverage = $CodeCoverageFiles
+        }
+
+        # Add Code Coverage OutputFile if specified
+        if (-not [string]::IsNullOrEmpty($CodeCoverageOutputFile)) {
             $pesterParams.CodeCoverageOutputFile = $CodeCoverageOutputFile
             $pesterParams.CodeCoverageOutputFileFormat = $CodeCoverageOutputFileFormat
         }

--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -21,7 +21,7 @@ function Test-PSBuildPester {
     .PARAMETER CodeCoverageOutputFile
         Output path to store Pester code coverage results to..
     .PARAMETER CodeCoverageOutputFileFormat
-        code coverage result output format (JoCoCo).
+        code coverage result output format (JaCoCo).
     .PARAMETER ImportModule
         Import module from OutDir prior to running Pester tests.
     .EXAMPLE

--- a/PowerShellBuild/build.properties.ps1
+++ b/PowerShellBuild/build.properties.ps1
@@ -79,14 +79,6 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
             # Fail Pester code coverage test if below this threshold
             Threshold = .75
 
-            # CodeCoverageFiles specifies the files to perform code coverage analysis on. This property
-            # acts as a direct input to the Pester -CodeCoverage parameter, so will support constructions
-            # like the ones found here: https://github.com/pester/Pester/wiki/Code-Coverage.
-            Files = @(
-                Join-Path -Path $env:BHPSModulePath -ChildPath '*.ps1'
-                Join-Path -Path $env:BHPSModulePath -ChildPath '*.psm1'
-            )
-
             # Specifies an output file path to send to Invoke-Pester's -CodeCoverageOutputFile parameter.
             # This is typically used to write out code coverage results so that they can be sent to a CI
             # system like Azure Devops.
@@ -95,6 +87,14 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
             # Specifies the code coverage output format to use when the CodeCoverageOutputFile property is given
             # a path.  This parameter is passed through to Invoke-Pester's -CodeCoverageOutputFileFormat parameter.
             OutputFileFormat = $null
+
+            # CodeCoverageFiles specifies the files to perform code coverage analysis on. This property
+            # acts as a direct input to the Pester -CodeCoverage parameter, so will support constructions
+            # like the ones found here: https://github.com/pester/Pester/wiki/Code-Coverage.
+            Files = @(
+                Join-Path -Path $env:BHPSModulePath -ChildPath '*.ps1'
+                Join-Path -Path $env:BHPSModulePath -ChildPath '*.psm1'
+            )
         }
     }
     Help  = @{

--- a/PowerShellBuild/build.properties.ps1
+++ b/PowerShellBuild/build.properties.ps1
@@ -86,6 +86,15 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
                 Join-Path -Path $env:BHPSModulePath -ChildPath '*.ps1'
                 Join-Path -Path $env:BHPSModulePath -ChildPath '*.psm1'
             )
+
+            # Specifies an output file path to send to Invoke-Pester's -CodeCoverageOutputFile parameter.
+            # This is typically used to write out code coverage results so that they can be sent to a CI
+            # system like Azure Devops.
+            OutputFile = $null
+
+            # Specifies the code coverage output format to use when the CodeCoverageOutputFile property is given
+            # a path.  This parameter is passed through to Invoke-Pester's -CodeCoverageOutputFileFormat parameter.
+            OutputFileFormat = $null
         }
     }
     Help  = @{

--- a/PowerShellBuild/build.properties.ps1
+++ b/PowerShellBuild/build.properties.ps1
@@ -86,7 +86,7 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
 
             # Specifies the code coverage output format to use when the CodeCoverageOutputFile property is given
             # a path.  This parameter is passed through to Invoke-Pester's -CodeCoverageOutputFileFormat parameter.
-            OutputFileFormat = 'JaCoCo'
+            OutputFileFormat = $null
 
             # CodeCoverageFiles specifies the files to perform code coverage analysis on. This property
             # acts as a direct input to the Pester -CodeCoverage parameter, so will support constructions

--- a/PowerShellBuild/build.properties.ps1
+++ b/PowerShellBuild/build.properties.ps1
@@ -86,7 +86,7 @@ $moduleVersion = (Import-PowerShellDataFile -Path $env:BHPSModuleManifest).Modul
 
             # Specifies the code coverage output format to use when the CodeCoverageOutputFile property is given
             # a path.  This parameter is passed through to Invoke-Pester's -CodeCoverageOutputFileFormat parameter.
-            OutputFileFormat = $null
+            OutputFileFormat = 'JaCoCo'
 
             # CodeCoverageFiles specifies the files to perform code coverage analysis on. This property
             # acts as a direct input to the Pester -CodeCoverage parameter, so will support constructions

--- a/PowerShellBuild/psakeFile.ps1
+++ b/PowerShellBuild/psakeFile.ps1
@@ -92,14 +92,16 @@ $pesterPreReqs = {
 }
 task Pester -depends Build -precondition $pesterPreReqs {
     $pesterParams = @{
-        Path                  = $PSBPreference.Test.RootDir
-        ModuleName            = $PSBPreference.General.ModuleName
-        OutputPath            = $PSBPreference.Test.OutputFile
-        OutputFormat          = $PSBPreference.Test.OutputFormat
-        CodeCoverage          = $PSBPreference.Test.CodeCoverage.Enabled
-        CodeCoverageThreshold = $PSBPreference.Test.CodeCoverage.Threshold
-        CodeCoverageFiles     = $PSBPreference.Test.CodeCoverage.Files
-        ImportModule          = $PSBPreference.Test.ImportModule
+        Path                         = $PSBPreference.Test.RootDir
+        ModuleName                   = $PSBPreference.General.ModuleName
+        OutputPath                   = $PSBPreference.Test.OutputFile
+        OutputFormat                 = $PSBPreference.Test.OutputFormat
+        CodeCoverage                 = $PSBPreference.Test.CodeCoverage.Enabled
+        CodeCoverageThreshold        = $PSBPreference.Test.CodeCoverage.Threshold
+        CodeCoverageFiles            = $PSBPreference.Test.CodeCoverage.Files
+        CodeCoverageOutputFile       = $PSBPreference.Test.CodeCoverage.OutputFile
+        CodeCoverageOutputFileFormat = $PSBPreference.Test.CodeCoverage.OutputFormat
+        ImportModule                 = $PSBPreference.Test.ImportModule
     }
     Test-PSBuildPester @pesterParams
 } -description 'Execute Pester tests'

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can override these in either psake or Invoke-Build to match your environment
 | $PSBPreference.Test.CodeCoverage.Threshold | .75 | Fail Pester code coverage test if below this threshold
 | $PSBPreference.Test.CodeCoverage.Files | *.ps1, *.psm1 | Files to perform code coverage analysis on
 | $PSBPreference.Test.CodeCoverage.OutputFile | $null | Output file path Pester will save code coverage results to
-| $PSBPreference.Test.CodeCoverage.OutputFileFormat | JoCoCo | Test output format to use when saving Pester code coverage results
+| $PSBPreference.Test.CodeCoverage.OutputFileFormat | JaCoCo | Test output format to use when saving Pester code coverage results
 | $PSBPreference.Test.ImportModule | $false | Import module from output directory prior to running Pester tests
 | $PSBPreference.Help.UpdatableHelpOutDir | $OutDir/UpdatableHelp | Output directory to store update module help (CAB)
 | $PSBPreference.Help.DefaultLocale | (Get-UICulture).Name | Default locale used for help generation

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can override these in either psake or Invoke-Build to match your environment
 | $PSBPreference.Test.CodeCoverage.Threshold | .75 | Fail Pester code coverage test if below this threshold
 | $PSBPreference.Test.CodeCoverage.Files | *.ps1, *.psm1 | Files to perform code coverage analysis on
 | $PSBPreference.Test.CodeCoverage.OutputFile | $null | Output file path Pester will save code coverage results to
-| $PSBPreference.Test.CodeCoverage.OutputFileFormat | JaCoCo | Test output format to use when saving Pester code coverage results
+| $PSBPreference.Test.CodeCoverage.OutputFileFormat | $null | Test output format to use when saving Pester code coverage results
 | $PSBPreference.Test.ImportModule | $false | Import module from output directory prior to running Pester tests
 | $PSBPreference.Help.UpdatableHelpOutDir | $OutDir/UpdatableHelp | Output directory to store update module help (CAB)
 | $PSBPreference.Help.DefaultLocale | (Get-UICulture).Name | Default locale used for help generation

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ You can override these in either psake or Invoke-Build to match your environment
 | $PSBPreference.Test.CodeCoverage.Enabled | $false | Enable/disable Pester code coverage reporting
 | $PSBPreference.Test.CodeCoverage.Threshold | .75 | Fail Pester code coverage test if below this threshold
 | $PSBPreference.Test.CodeCoverage.Files | *.ps1, *.psm1 | Files to perform code coverage analysis on
+| $PSBPreference.Test.CodeCoverage.OutputFile | $null | Output file path Pester will save code coverage results to
+| $PSBPreference.Test.CodeCoverage.OutputFileFormat | JoCoCo | Test output format to use when saving Pester code coverage results
 | $PSBPreference.Test.ImportModule | $false | Import module from output directory prior to running Pester tests
 | $PSBPreference.Help.UpdatableHelpOutDir | $OutDir/UpdatableHelp | Output directory to store update module help (CAB)
 | $PSBPreference.Help.DefaultLocale | (Get-UICulture).Name | Default locale used for help generation

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -5,7 +5,7 @@
 
     BuildHelpers     = 'latest'
     Pester           = @{
-        Version = 'latest'
+        Version = '4.10.1'
         Parameters = @{
             SkipPublisherCheck = $true
         }


### PR DESCRIPTION
I added 2 new params to allow the output of Pester Code coverage reports to a file.
* CodeCoverageOutputFile
* CodeCoverageOutputFileFormat

## Related Issue
Issue #48 - Add pester code coverage output parameters 

## Motivation and Context
I am using Azure Devops to build a module and I want to display the code coverage report in Azure Devops.

## How Has This Been Tested?
I have used the updated code in a module build and it successfully produced the code coverage report in the proper location.   I was able to update the properties in my psakeFile to change this location successfully. I also confirmed that the build still works successfully without the code coverage report. The code passed all of the current pester test.  I am unsure were I would add any pester test for this enhancement.  If you point me to the proper place I think a test to confirm the output file exist would be pretty easy.  

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.