### PR TITLE
Invoke-Build Task Improvements

### DIFF
--- a/PowerShellBuild/IB.tasks.ps1
+++ b/PowerShellBuild/IB.tasks.ps1
@@ -181,7 +181,7 @@ Task Publish Test, {
 task BuildHelp GenerateMarkdown,GenerateMAML
 
 Task Build {
-    if ($PSBPreference.Build.Dependencies -ne $__DefaultBuildDependencies) {
+    if ([String]$PSBPreference.Build.Dependencies -ne [String]$__DefaultBuildDependencies) {
         throw [NotSupportedException]'You cannot use $PSBPreference.Build.Dependencies with Invoke-Build. Please instead redefine the build task or your default task to include your dependencies. Example: Task . Dependency1,Dependency2,Build,Test or Task Build Dependency1,Dependency2,StageFiles'
     }
 },StageFiles,BuildHelp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Invoke-Build Task Fixes
Fix: StageFiles and Pester brought in line with PSake equivalents
Fix: Prereqs as If conditionals
Fix: Dependencies variable doesn't work because Invoke-Build tasks compile dependencies ahead of time. Throw an error instead with proper override guidance
