### PR TITLE
Changes $configuration.Run.PassThru to $True

### DIFF
--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -77,7 +77,7 @@ function Test-PSBuildPester {
         Import-Module Pester -MinimumVersion 5.0.0
         $configuration = [PesterConfiguration]::Default
         $configuration.Output.Verbosity        = 'Detailed'
-        $configuration.Run.PassThru            = $false
+        $configuration.Run.PassThru            = $true
         $configuration.TestResult.Enabled      = -not [string]::IsNullOrEmpty($OutputPath)
         $configuration.TestResult.OutputPath   = $OutputPath
         $configuration.TestResult.OutputFormat = $OutputFormat


### PR DESCRIPTION
Before Pester V5, the -PassThru parameter was used.

We could either use the -PassThru parameter, or set the run configuration in the Configuration Parameter.

## Description
Currently, the Pester task never really fails, because Invoke-Pester doesn't PassThru

## Related Issue
#51 

## Motivation and Context
Before the migration to PesterV5, the PassThru parameter was used, and the replacement in V5 was set to false in the PSBuild Task

## How Has This Been Tested?
Changing it in my machine makes the task fail as it should.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
