### PR TITLE
Added Module parameter and an [IO.Path]::Combine() to Build-PSBuildUpdatableHelp

### DIFF
--- a/PowerShellBuild/Public/Build-PSBuildUpdatableHelp.ps1
+++ b/PowerShellBuild/Public/Build-PSBuildUpdatableHelp.ps1
@@ -8,6 +8,8 @@ function Build-PSBuildUpdatableHelp {
         Path to PlatyPS markdown help files.
     .PARAMETER OutputPath
         Path to create updatable help .cab file in.
+    .PARAMETER Module
+        Name of the module to create a .cab file for. Defaults to the $ModuleName variable from the parent scope.
     .EXAMPLE
         PS> Build-PSBuildUpdatableHelp -DocsPath ./docs -OutputPath ./Output/UpdatableHelp
 

--- a/PowerShellBuild/Public/Build-PSBuildUpdatableHelp.ps1
+++ b/PowerShellBuild/Public/Build-PSBuildUpdatableHelp.ps1
@@ -19,7 +19,9 @@ function Build-PSBuildUpdatableHelp {
         [string]$DocsPath,
 
         [parameter(Mandatory)]
-        [string]$OutputPath
+        [string]$OutputPath,
+
+        [string]$Module = $ModuleName
     )
 
     if ($null -ne $IsWindows -and -not $IsWindows) {
@@ -42,7 +44,7 @@ function Build-PSBuildUpdatableHelp {
     foreach ($locale in $helpLocales) {
         $cabParams = @{
             CabFilesFolder  = [IO.Path]::Combine($moduleOutDir, $locale)
-            LandingPagePath = "$DocsPath/$locale/$ModuleName.md"
+            LandingPagePath = [IO.Path]::Combine($DocsPath, $locale, "$Module.md")
             OutputFolder    = $OutputPath
             Verbose         = $VerbosePreference
         }


### PR DESCRIPTION
## Description

The Module parameter removes the dependency on the $ModuleName variable in the parent scope while maintaining the existing behavior of inheriting its value.

The LandingPagePath key in $cabParams now uses the [IO.Path]::Combine([string[]]) method rather than manual string concatenation

## Related Issue

https://github.com/psake/PowerShellBuild/issues/54

## Motivation and Context
This will make it easier to use Build-PSBuildUpdatableHelp in custom psake files or other contexts

## How Has This Been Tested?

All 195 existing Pester tests passed

Also tested in a vacuum as demonstrated by the example in the Issue

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.  (I think?  Should I do anything other than the comment-based help?)
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (Sorry, I don't know where to do this, don't see existing per-function tests, I am a testing n00b)
- [x] All new and existing tests passed.
