### PR TITLE
Substitute use of IsPathFullyQualified to restore Windows PowerShell compatibility

### DIFF
--- a/PowerShellBuild/Public/Initialize-PSBuild.ps1
+++ b/PowerShellBuild/Public/Initialize-PSBuild.ps1
@@ -22,7 +22,7 @@ function Initialize-PSBuild {
         [switch]$UseBuildHelpers
     )
 
-    if ([IO.Path]::IsPathFullyQualified($BuildEnvironment.Build.OutDir)) {
+    if ($BuildEnvironment.Build.OutDir.StartsWith($env:BHProjectPath, [System.StringComparison]::InvariantCultureIgnoreCase)) {
         $BuildEnvironment.Build.ModuleOutDir = [IO.Path]::Combine($BuildEnvironment.Build.OutDir, $env:BHProjectName, $BuildEnvironment.General.ModuleVersion)
     } else {
         $BuildEnvironment.Build.ModuleOutDir = [IO.Path]::Combine($env:BHProjectPath, $BuildEnvironment.Build.OutDir, $env:BHProjectName, $BuildEnvironment.General.ModuleVersion)

--- a/PowerShellBuild/Public/Initialize-PSBuild.ps1
+++ b/PowerShellBuild/Public/Initialize-PSBuild.ps1
@@ -22,7 +22,7 @@ function Initialize-PSBuild {
         [switch]$UseBuildHelpers
     )
 
-    if ($BuildEnvironment.Build.OutDir.StartsWith($env:BHProjectPath, [System.StringComparison]::InvariantCultureIgnoreCase)) {
+    if ($BuildEnvironment.Build.OutDir.StartsWith($env:BHProjectPath, [StringComparison]::OrdinalIgnoreCase)) {
         $BuildEnvironment.Build.ModuleOutDir = [IO.Path]::Combine($BuildEnvironment.Build.OutDir, $env:BHProjectName, $BuildEnvironment.General.ModuleVersion)
     } else {
         $BuildEnvironment.Build.ModuleOutDir = [IO.Path]::Combine($env:BHProjectPath, $BuildEnvironment.Build.OutDir, $env:BHProjectName, $BuildEnvironment.General.ModuleVersion)


### PR DESCRIPTION
## Description
The `Initialize-PSBuild` function was not compatible with .NET Framework / PowerShell 5.1 due to the use of the `System.IO.Path.IsPathFullyQualified()` method, introduced with the fix for #27. I changed the function to check if the value of OutDir already started with BHProjectPath rather than testing if OutDir was a fully qualified path on its own.

This seems to have solved the issue and tests are passing. Also, changing the value of `$PSBPreference.Build.OutDir` seems to result in the same behavior before and after the change introduced in this PR, though I don't think any tests were introduced to specifically test the original fix so I'm not 100% certain this is the best solution.

## Related Issue
Issue #53 

## Motivation and Context
I still regularly work with PowerShell 5.1 due to legacy .NET Framework dependencies that I'm required to use. I began to use the Stucco module for setting up my modules, but I cannot call `.\build.ps1` from Windows PowerShell because the PowerShellBuild `Initialize-PSBuild` command calls a method that is not available in .NET Framework. I am now using this modified version of PowerShellBuild.

## How Has This Been Tested?
I verified that I can build modules using the Stucco template on Windows using Windows PowerShell, and PowerShell 7, as well as Ubuntu on WSL2 using PowerShell 7. I tested these builds with and without a custom `$PSBPreference.Build.OutDir` value set in my psakefile.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
