### PR TITLE
Fix for  CodeCoverage and Instruction and Lines results were always 0.00

### DIFF
--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -104,7 +104,7 @@ function Test-PSBuildPester {
                 [xml]$testCoverage = Get-Content $CodeCoverageOutputFile
                 $ccReport = $testCoverage.report.counter.ForEach({
                     $total = [int]$_.missed + [int]$_.covered
-                    $perc  = [Math]::Truncate([int]$_.covered / $total)
+                    $perc  = ([int]$_.covered / $total)
                     [pscustomobject]@{
                         name    = $textInfo.ToTitleCase($_.Type.ToLower())
                         percent = $perc


### PR DESCRIPTION
My Build was not completing anymore since I activated the Code Coverage, until I removed "[Math]::Truncate"
for the $perc VAR.

I am still able to set and change the threshold for the percentage required to for the build to pass,
this should be the solution to the problem.

## Motivation and Context
I want to use the code coverage for my projects

## How Has This Been Tested?
I changed the code coverage threshold to fail and path my builds, and finally the numbers compared as excepted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
