### PR TITLE
Build-PSBuildModule Compile UTF-8 File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- [**#71**](https://github.com/psake/PowerShellBuild/pull/71) Compiled modules
+  are now explicitly created as UTF-8 files.
+
+
 ## [0.6.2] 2024-10-06
 
 ### Changed

--- a/PowerShellBuild/Public/Build-PSBuildModule.ps1
+++ b/PowerShellBuild/Public/Build-PSBuildModule.ps1
@@ -104,7 +104,7 @@ function Build-PSBuildModule {
         # Grab the contents of the copied over PSM1
         # This will be appended to the end of the finished PSM1
         $psm1Contents = Get-Content -Path $rootModule -Raw
-        '' | Out-File -FilePath $rootModule
+        '' | Out-File -FilePath $rootModule -Encoding utf8
 
         if ($CompileHeader) {
             $CompileHeader | Add-Content -Path $rootModule -Encoding utf8


### PR DESCRIPTION
We attempt to append UTF-8 encodings later, but the initial file isn't set to that. This should fix it.

## Description
When building a compiled module it was observed that the the Meta tests to check for UTF-8 was filing on the newly created psm1. This fix sets the intial file to be utf-8 encoded.
```
Running tests from 'Meta.tests.ps1'
WARNING: File 
D:\actions-runner\_work\InternalModule\InternalModule\Output\InternalModule\0.7.0\InternalModule.psm1 contains 0x00 bytes. It probably uses Unicode/UTF-16 and needs to be converted to UTF-8. Use Fixer 
"Get-UnicodeFilesList $pwd | ConvertTo-UTF8".
Error: [-] Meta.tests.ps1 failed with:
Message
  Expected 0, but got 1.
  at $unicodeFilesCount | Should -Be 0, D:\actions-runner\_work\InternalModule\InternalModule\tests\Meta.tests.ps1:24
  at <ScriptBlock>, D:\actions-runner\_work\InternalModule\InternalModule\tests\Meta.tests.ps1:24
  ```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have added this change to the CHANGELOG.md.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
