### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Test
       shell: pwsh
       run: ./build.ps1 -Task Test -Bootstrap


### PR DESCRIPTION
The GitHub action `actions/checkout@v1` is around 6 years old now. This PR bumps us to `actions/checkout@v4`.