### PR TITLE
Add tests for Test-PSBuildScriptAnalysis (fixes #96)

### DIFF
--- a/PowerShellBuild/Public/Test-PSBuildScriptAnalysis.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildScriptAnalysis.ps1
@@ -29,9 +29,9 @@ function Test-PSBuildScriptAnalysis {
     Write-Verbose ($LocalizedData.SeverityThresholdSetTo -f $SeverityThreshold)
 
     $analysisResult = Invoke-ScriptAnalyzer -Path $Path -Settings $SettingsPath -Recurse -Verbose:$VerbosePreference
-    $errors = ($analysisResult.where({ $_Severity -eq 'Error' })).Count
-    $warnings = ($analysisResult.where({ $_Severity -eq 'Warning' })).Count
-    $infos = ($analysisResult.where({ $_Severity -eq 'Information' })).Count
+    $errors = ($analysisResult.where({ $_.Severity -eq 'Error' })).Count
+    $warnings = ($analysisResult.where({ $_.Severity -eq 'Warning' })).Count
+    $infos = ($analysisResult.where({ $_.Severity -eq 'Information' })).Count
 
     if ($analysisResult) {
         Write-Host $LocalizedData.PSScriptAnalyzerResults -ForegroundColor Yellow

--- a/tests/Test-PSBuildScriptAnalysis.tests.ps1
+++ b/tests/Test-PSBuildScriptAnalysis.tests.ps1
@@ -1,0 +1,57 @@
+Describe 'Test-PSBuildScriptAnalysis' {
+    BeforeAll {
+        Set-StrictMode -Version Latest
+
+        . (Join-Path -Path $PSScriptRoot -ChildPath '../PowerShellBuild/Public/Test-PSBuildScriptAnalysis.ps1')
+
+        $script:LocalizedData = @{
+            SeverityThresholdSetTo = 'Severity threshold set to {0}'
+            PSScriptAnalyzerResults = 'PSScriptAnalyzer results'
+            ScriptAnalyzerErrors    = 'ScriptAnalyzer errors found'
+            ScriptAnalyzerWarnings  = 'ScriptAnalyzer warnings found'
+            ScriptAnalyzerIssues    = 'ScriptAnalyzer issues found'
+        }
+    }
+
+    It 'calls Invoke-ScriptAnalyzer with the provided settings path' {
+        Mock -CommandName Invoke-ScriptAnalyzer -MockWith {
+            @()
+        }
+
+        Test-PSBuildScriptAnalysis -Path 'function Test-Me { "ok" }' -SeverityThreshold Error -SettingsPath 'tests/ScriptAnalyzerSettings.psd1'
+
+        Should -Invoke -CommandName Invoke-ScriptAnalyzer -Times 1 -Exactly -ParameterFilter {
+            $Path -eq 'function Test-Me { "ok" }' -and
+            $Settings -eq 'tests/ScriptAnalyzerSettings.psd1' -and
+            $Recurse
+        }
+    }
+
+    It 'passes when no results are returned at Error threshold' {
+        Mock -CommandName Invoke-ScriptAnalyzer -MockWith {
+            @()
+        }
+
+        {
+            Test-PSBuildScriptAnalysis -Path 'function Test-Me { "ok" }' -SeverityThreshold Error
+        } | Should -Not -Throw
+    }
+
+    It 'fails when an error is returned at Error threshold' {
+        Mock -CommandName Invoke-ScriptAnalyzer -MockWith {
+            @(
+                [pscustomobject]@{
+                    Severity   = 'Error'
+                    RuleName   = 'TestRule'
+                    ScriptName = 'inline.ps1'
+                    Message    = 'Boom'
+                    Line       = 1
+                }
+            )
+        }
+
+        {
+            Test-PSBuildScriptAnalysis -Path 'function Test-Me { "ok" }' -SeverityThreshold Error
+        } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Pester test file for `Test-PSBuildScriptAnalysis`
- verify `Invoke-ScriptAnalyzer` is called with the provided `-SettingsPath`
- verify pass/fail behavior at `-SeverityThreshold Error`
- fix severity counting by using `$_.Severity` in the analyzer result filters

## Validation
- Added targeted Pester scenarios requested in #96
- Local execution not run in this environment because PowerShell (`pwsh`) is unavailable; CI should run the suite on PR

Closes #96
