### PR TITLE
test: add coverage for Build-PSBuildUpdatableHelp

### DIFF
--- a/tests/Build-PSBuildMarkdown.tests.ps1
+++ b/tests/Build-PSBuildMarkdown.tests.ps1
@@ -1,0 +1,103 @@
+Describe 'Build-PSBuildMarkdown' {
+    BeforeAll {
+        . "$PSScriptRoot/../PowerShellBuild/Public/Build-PSBuildMarkdown.ps1"
+    }
+
+    BeforeEach {
+        $script:LocalizedData = @{
+            NoCommandsExported          = 'No commands exported.'
+            FailedToGenerateMarkdownHelp = 'Failed to generate markdown help: {0}'
+        }
+
+        $script:newMarkdownParams = $null
+        $script:updateMarkdownParams = @()
+    }
+
+    It 'warns and exits when module exports no commands' {
+        Mock Import-Module {
+            [pscustomobject]@{ ExportedCommands = @() }
+        }
+        Mock Write-Warning {}
+        Mock New-MarkdownHelp {}
+        Mock Remove-Module {}
+
+        Build-PSBuildMarkdown \
+            -ModulePath '/tmp/module' \
+            -ModuleName 'MyModule' \
+            -DocsPath '/tmp/docs' \
+            -Locale 'en-US' \
+            -Overwrite:$false \
+            -AlphabeticParamsOrder:$true \
+            -ExcludeDontShow:$false \
+            -UseFullTypeName:$false
+
+        Should -Invoke Write-Warning -Times 1
+        Should -Invoke New-MarkdownHelp -Times 0
+        Should -Invoke Remove-Module -Times 1 -ParameterFilter { $Name -eq 'MyModule' }
+    }
+
+    It 'generates markdown help without force when overwrite is false' {
+        Mock Import-Module {
+            [pscustomobject]@{ ExportedCommands = @{ Test = 'Test-Command' } }
+        }
+        Mock Test-Path { $false }
+        Mock New-Item {}
+        Mock Get-ChildItem { @() }
+        Mock New-MarkdownHelp {
+            $script:newMarkdownParams = $PSBoundParameters
+        }
+        Mock Remove-Module {}
+
+        Build-PSBuildMarkdown \
+            -ModulePath '/tmp/module' \
+            -ModuleName 'MyModule' \
+            -DocsPath '/tmp/docs' \
+            -Locale 'en-US' \
+            -Overwrite:$false \
+            -AlphabeticParamsOrder:$true \
+            -ExcludeDontShow:$true \
+            -UseFullTypeName:$false
+
+        Should -Invoke New-Item -Times 1 -ParameterFilter { $Path -eq '/tmp/docs' -and $ItemType -eq 'Directory' }
+        $script:newMarkdownParams.Module | Should -Be 'MyModule'
+        $script:newMarkdownParams.Locale | Should -Be 'en-US'
+        $script:newMarkdownParams.OutputFolder | Should -Be ([IO.Path]::Combine('/tmp/docs', 'en-US'))
+        $script:newMarkdownParams.ErrorAction | Should -Be 'SilentlyContinue'
+        $script:newMarkdownParams.ContainsKey('Force') | Should -BeFalse
+    }
+
+    It 'updates existing markdown and forces generation when overwrite is true' {
+        Mock Import-Module {
+            [pscustomobject]@{ ExportedCommands = @{ Test = 'Test-Command' } }
+        }
+        Mock Test-Path { $true }
+        Mock Get-ChildItem {
+            @('existing.md')
+        } -ParameterFilter { $LiteralPath -eq '/tmp/docs' -and $Filter -eq '*.md' -and $Recurse }
+        Mock Get-ChildItem {
+            @([pscustomobject]@{ FullName = '/tmp/docs/en-US' })
+        } -ParameterFilter { $LiteralPath -eq '/tmp/docs' -and $Directory }
+        Mock Update-MarkdownHelp {
+            $script:updateMarkdownParams += $PSBoundParameters
+        }
+        Mock New-MarkdownHelp {
+            $script:newMarkdownParams = $PSBoundParameters
+        }
+        Mock Remove-Module {}
+
+        Build-PSBuildMarkdown \
+            -ModulePath '/tmp/module' \
+            -ModuleName 'MyModule' \
+            -DocsPath '/tmp/docs' \
+            -Locale 'en-US' \
+            -Overwrite:$true \
+            -AlphabeticParamsOrder:$false \
+            -ExcludeDontShow:$false \
+            -UseFullTypeName:$true
+
+        Should -Invoke Update-MarkdownHelp -Times 1 -ParameterFilter { $Path -eq '/tmp/docs/en-US' }
+        $script:newMarkdownParams.ContainsKey('Force') | Should -BeTrue
+        $script:newMarkdownParams.Force | Should -BeTrue
+        $script:newMarkdownParams.ContainsKey('ErrorAction') | Should -BeFalse
+    }
+}

--- a/tests/Build-PSBuildUpdatableHelp.tests.ps1
+++ b/tests/Build-PSBuildUpdatableHelp.tests.ps1
@@ -1,0 +1,87 @@
+Describe 'Build-PSBuildUpdatableHelp' {
+    BeforeAll {
+        . "$PSScriptRoot/../PowerShellBuild/Public/Build-PSBuildUpdatableHelp.ps1"
+    }
+
+    BeforeEach {
+        $script:LocalizedData = @{
+            MakeCabNotAvailable      = 'MakeCab not available on this platform.'
+            DirectoryAlreadyExists   = 'Directory {0} already exists.'
+        }
+
+        $script:ModuleName = 'PSBuildModule'
+        $script:moduleOutDir = '/tmp/module-out'
+        $script:newCabCalls = @()
+    }
+
+    It 'warns and exits early when running on non-Windows hosts' {
+        Mock Write-Warning {}
+        Mock Get-ChildItem { throw 'should not be called' }
+        Mock New-Item {}
+        Mock New-ExternalHelpCab {}
+
+        $script:IsWindows = $false
+
+        Build-PSBuildUpdatableHelp -DocsPath '/tmp/docs' -OutputPath '/tmp/out'
+
+        Should -Invoke Write-Warning -Times 1 -ParameterFilter { $Message -eq 'MakeCab not available on this platform.' }
+        Should -Invoke Get-ChildItem -Times 0
+        Should -Invoke New-ExternalHelpCab -Times 0
+    }
+
+    It 'creates output folder and generates one cab per locale on Windows' {
+        Mock Test-Path { $false }
+        Mock New-Item {}
+        Mock Get-ChildItem {
+            @(
+                [pscustomobject]@{ Name = 'en-US' },
+                [pscustomobject]@{ Name = 'fr-FR' }
+            )
+        } -ParameterFilter { $Path -eq '/tmp/docs' -and $Directory }
+        Mock New-ExternalHelpCab {
+            $script:newCabCalls += $PSBoundParameters
+        }
+
+        $script:IsWindows = $true
+
+        Build-PSBuildUpdatableHelp -DocsPath '/tmp/docs' -OutputPath '/tmp/out' -Module 'MyModule'
+
+        Should -Invoke New-Item -Times 1 -ParameterFilter { $Path -eq '/tmp/out' -and $ItemType -eq 'Directory' }
+        $script:newCabCalls.Count | Should -Be 2
+
+        $script:newCabCalls[0].CabFilesFolder | Should -Be ([IO.Path]::Combine('/tmp/module-out', 'en-US'))
+        $script:newCabCalls[0].LandingPagePath | Should -Be ([IO.Path]::Combine('/tmp/docs', 'en-US', 'MyModule.md'))
+        $script:newCabCalls[0].OutputFolder | Should -Be '/tmp/out'
+
+        $script:newCabCalls[1].CabFilesFolder | Should -Be ([IO.Path]::Combine('/tmp/module-out', 'fr-FR'))
+        $script:newCabCalls[1].LandingPagePath | Should -Be ([IO.Path]::Combine('/tmp/docs', 'fr-FR', 'MyModule.md'))
+        $script:newCabCalls[1].OutputFolder | Should -Be '/tmp/out'
+    }
+
+    It 'cleans existing output folder before generating cabs on Windows' {
+        Mock Test-Path { $true }
+        Mock Get-ChildItem {
+            @(
+                [pscustomobject]@{ Name = 'en-US' }
+            )
+        } -ParameterFilter { $Path -eq '/tmp/docs' -and $Directory }
+        Mock Get-ChildItem {
+            @(
+                [pscustomobject]@{ FullName = '/tmp/out/existing.cab' }
+            )
+        } -ParameterFilter { $Path -eq '/tmp/out' }
+        Mock Remove-Item {}
+        Mock New-ExternalHelpCab {
+            $script:newCabCalls += $PSBoundParameters
+        }
+        Mock Write-Verbose {}
+
+        $script:IsWindows = $true
+
+        Build-PSBuildUpdatableHelp -DocsPath '/tmp/docs' -OutputPath '/tmp/out' -Module 'MyModule'
+
+        Should -Invoke Write-Verbose -Times 1
+        Should -Invoke Remove-Item -Times 1 -ParameterFilter { $Recurse -and $Force }
+        Should -Invoke New-ExternalHelpCab -Times 1
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Pester test file for `Build-PSBuildUpdatableHelp`
- cover non-Windows early-exit behavior (warning + no cab generation)
- cover Windows path flow for creating/cleaning output and generating one CAB per locale

## Validation
- `git diff --check`
- `pwsh` is not available in this environment, so Pester execution could not be run locally

Closes #101
