### PR TITLE
test: add shared fixture module skeleton for integration tests

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,5 @@
+# Shared test fixtures
+
+`tests/fixtures/TestModule/` contains a minimal reusable PowerShell module skeleton (`.psm1` + `.psd1`) for integration tests.
+
+This fixture is intended to support test tasks tracked under issue #17.

--- a/tests/fixtures/TestModule/TestModule.psd1
+++ b/tests/fixtures/TestModule/TestModule.psd1
@@ -1,0 +1,20 @@
+@{
+    RootModule        = 'TestModule.psm1'
+    ModuleVersion     = '0.1.0'
+    GUID              = '9dc6c759-5ea0-4d9e-9392-947de76810f2'
+    Author            = 'PowerShellBuild Contributors'
+    CompanyName       = 'Community'
+    Copyright         = '(c) PowerShellBuild Contributors. All rights reserved.'
+    Description       = 'Minimal shared fixture module for integration tests.'
+    PowerShellVersion = '3.0'
+    RequiredModules   = @()
+    FunctionsToExport = @('Get-TestFixtureMessage')
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+    PrivateData       = @{
+        PSData = @{
+            Tags = @('tests','fixtures')
+        }
+    }
+}

--- a/tests/fixtures/TestModule/TestModule.psm1
+++ b/tests/fixtures/TestModule/TestModule.psm1
@@ -1,0 +1,4 @@
+# Minimal shared fixture module for integration tests.
+function Get-TestFixtureMessage {
+    'PowerShellBuild fixture module loaded'
+}


### PR DESCRIPTION
## Summary
- add a minimal shared fixture module at `tests/fixtures/TestModule/`
- include a bare `.psm1` and `.psd1` skeleton suitable for reuse by integration tests
- document fixture purpose in `tests/fixtures/README.md`

Fixes #97

## Validation
- `git diff --check HEAD~1..HEAD`
