### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches: [ $default-branch ]


### PR DESCRIPTION
Potential fix for [https://github.com/psake/PowerShellBuild/security/code-scanning/3](https://github.com/psake/PowerShellBuild/security/code-scanning/3)

In general, this should be fixed by explicitly defining GITHUB_TOKEN permissions in the workflow, either at the root level (applying to all jobs) or per job, and restricting them to the least privilege required (for a simple test workflow usually `contents: read` is enough). This documents the workflow’s needs and prevents it from gaining broader access if repository or organization defaults change.

For this specific workflow in `.github/workflows/test.yml`, the safest, least intrusive fix that preserves existing behavior is to add a root-level `permissions:` block granting only `contents: read`. The existing steps perform a checkout and run a PowerShell script; there is no explicit indication they need to write to the repo, issues, or pull requests. Adding the block directly under the workflow `name:` (before `on:`) is conventional and applies to all jobs unless overridden. No imports or additional methods are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
