### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish


### PR DESCRIPTION
Potential fix for [https://github.com/psake/PowerShellBuild/security/code-scanning/1](https://github.com/psake/PowerShellBuild/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions:` block for the workflow or individual jobs, granting only the scopes actually needed. For most build/publish workflows that only need to read the repository contents, `contents: read` is an appropriate minimal default. If later steps need more permissions (e.g., to create releases or write issues), those can be added explicitly.

For this specific file, the simplest and safest fix without altering functionality is to add a workflow-level `permissions:` block with `contents: read`. This will apply to the `publish` job because it currently has no `permissions` of its own. Concretely, in `.github/workflows/publish.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block. No additional imports or dependencies are needed, and no other lines in the workflow need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
