### PR TITLE
docs: keep 0.8.1 changelog to user-facing changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Windows (matching the existing pattern in `Build-PSBuildUpdatableHelp`). Behavior
   on PowerShell 7+ is unchanged.
 
-### Added
-
-- An `Import smoke (Windows PowerShell 5.1)` CI job that parses and imports the
-  module on the real lowest-supported engine, so a construct that breaks import on
-  Windows PowerShell 5.1 (such as a PowerShell 7+-only ternary operator) fails CI
-  deterministically.
-
 ## [0.8.0] 2026-02-20
 
 ### Added


### PR DESCRIPTION
## Summary

Removes the `### Added` entry from the 0.8.1 CHANGELOG section. It documented an internal **CI job**, which isn't a user-facing change to the module (public functions, build tasks, `$PSBPreference`, or build/publish behavior).

## Why

- **Convention:** no prior release in this changelog (0.1.0 → 0.8.0) documents CI, test, or internal-tooling changes — only the module's user-facing surface. This entry was the sole exception.
- **It was also stale:** the bespoke `Import smoke (Windows PowerShell 5.1)` job it described was replaced in #126 by the shared `psake/.github` ModuleCI workflow's full 5.1 **test** run, so the text no longer matched what shipped.

The user-facing `### Fixed` entry (the 5.1 import regression) is unchanged — that one genuinely affects consumers and stays.

Prep for cutting the `v0.8.1` release so the release notes reflect only what users care about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)