### PR TITLE
chore: Pin Pester 5.8.0 and update PSScriptAnalyzer to 1.25.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Output/
+tests/out/

--- a/instructions/repository-specific.instructions.md
+++ b/instructions/repository-specific.instructions.md
@@ -14,10 +14,10 @@ file only adds repo-specific concepts.
 **PowerShellBuild** is a PowerShell module that provides standardized build, test, and publish
 tasks for other PowerShell module projects. It supports two task-runner frameworks:
 
-- **psake** (4.9.0+)
-- **Invoke-Build** (5.8.1+)
+- **psake**
+- **Invoke-Build**
 
-- Current version: **0.8.1** (see `PowerShellBuild/PowerShellBuild.psd1`)
+- Current version: see `ModuleVersion` in `PowerShellBuild/PowerShellBuild.psd1`
 - `PowerShellVersion` in the manifest is currently `'3.0'` — almost certainly wrong; under
   review in the v1.0.0 roadmap (psake/PowerShellBuild#120)
 - Cross-platform: Windows, Linux, macOS (CI matrix in `.github/workflows/test.yml`)
@@ -220,16 +220,17 @@ no-ops on non-Windows.
 
 ## Dependencies
 
-Defined in `requirements.psd1`, installed via **PSDepend** when `./build.ps1 -Bootstrap` runs:
+Defined in `requirements.psd1` — the source of truth for build-dependency names and pinned
+versions — and installed via **PSDepend** when `./build.ps1 -Bootstrap` runs:
 
-| Module           | Version  |
-| ---------------- | -------- |
-| BuildHelpers     | 2.0.16   |
-| Pester           | 5.8.0    |
-| psake            | 4.9.0    |
-| PSScriptAnalyzer | 1.25.0   |
-| InvokeBuild      | 5.8.1    |
-| platyPS          | 0.14.2   |
+| Module           | Purpose                                                    |
+| ---------------- | ---------------------------------------------------------- |
+| BuildHelpers     | Populates the `BH*` build environment variables            |
+| Pester           | Test framework                                             |
+| psake            | Task runner for this repo's own build                      |
+| PSScriptAnalyzer | Static analysis of the built module                        |
+| InvokeBuild      | Alternate task runner (consumer-facing `IB.tasks.ps1`)     |
+| platyPS          | Help and documentation generation                          |
 
 ## Testing
 

--- a/instructions/repository-specific.instructions.md
+++ b/instructions/repository-specific.instructions.md
@@ -225,9 +225,9 @@ Defined in `requirements.psd1`, installed via **PSDepend** when `./build.ps1 -Bo
 | Module           | Version  |
 | ---------------- | -------- |
 | BuildHelpers     | 2.0.16   |
-| Pester           | ≥ 5.6.1  |
+| Pester           | 5.8.0    |
 | psake            | 4.9.0    |
-| PSScriptAnalyzer | 1.24.0   |
+| PSScriptAnalyzer | 1.25.0   |
 | InvokeBuild      | 5.8.1    |
 | platyPS          | 0.14.2   |
 

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -4,13 +4,13 @@
     }
     BuildHelpers     = '2.0.16'
     Pester           = @{
-        MinimumVersion = '5.6.1'
-        Parameters     = @{
+        Version    = '5.8.0'
+        Parameters = @{
             SkipPublisherCheck = $true
         }
     }
     psake            = '4.9.0'
-    PSScriptAnalyzer = '1.24.0'
+    PSScriptAnalyzer = '1.25.0'
     InvokeBuild      = '5.8.1'
     platyPS          = '0.14.2'
 }


### PR DESCRIPTION
## Summary

- Pin Pester to 5.8.0 (current stable, published 2026-06-30) in `requirements.psd1`. It previously floated via `MinimumVersion = '5.6.1'`, so CI installed whatever the newest release was at bootstrap time — this makes CI deterministic.
- Update PSScriptAnalyzer from 1.24.0 to 1.25.0, the latest stable release (2026-03-20).
- Stop duplicating dependency versions in `instructions/repository-specific.instructions.md`: the table now describes each module's purpose and points to `requirements.psd1` as the source of truth, so this class of PR never has to touch the instructions again. Hardcoded module/task-runner version numbers are dropped for the same reason.
- Add `tests/out/` to `.gitignore` — the Pester task writes `tests/out/testResults.xml` on every run (for the CI artifact upload), leaving untracked clutter after local test runs.

The consumer-facing minimum in `PowerShellBuild.psd1` (`Pester >= 5.6.1` in `RequiredModules`) is intentionally unchanged — raising it would force the new version on consumers, which is a separate decision.

## Test Plan

- [x] Full local run of `./build.ps1 -Task Test` with the exact pinned versions (psake 4.9.0, PSScriptAnalyzer 1.25.0, Pester 5.8.0): 314 passed, 0 failed, Analyze clean (warnings only).
- [x] `git check-ignore tests/out/testResults.xml` confirms the new ignore rule matches.
- [x] CI matrix green on all platforms.

## Breaking Changes

None (build-time dependencies and repo docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHgRWPi4D2aun7CEtwLz7T