### PR TITLE
chore: Add GitHub Projects MCP server for AI agent board access

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github-projects": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/x/projects",
+      "headers": {
+        "Authorization": "Bearer ${GH_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a repo-scoped `.mcp.json` pointing at the official GitHub MCP server's [projects toolset](https://github.blog/changelog/2026-01-28-github-mcp-server-new-projects-tools-oauth-scope-filtering-and-new-features/) (`projects_list`, `projects_get`, `projects_write`), giving AI agents full CRUD access to the [psake org project board](https://github.com/orgs/psake/projects/2)
- Claude Code cloud sessions cannot reach Projects v2 any other way: their GitHub API proxy serves only a pinned set of GraphQL operations, and Projects v2 has no REST API, so `gh project` fails there. The MCP server routes over plain HTTPS to `api.githubcopilot.com`, where GitHub executes the GraphQL server-side
- Authentication uses a `GH_TOKEN` environment variable (classic PAT with `project` scope, or fine-grained PAT with Projects permissions). Anyone without `GH_TOKEN` set just sees the server as unavailable — no impact on existing workflows, humans, or CI

## Test Plan

- [x] JSON validity verified
- [x] Remote endpoint accepts PAT auth (MCP `initialize` handshake returns 200)
- [x] Full test suite unaffected (config-only change; no module code touched)
- [ ] After merge: a Claude Code cloud session on this repo verifies `projects_get` reads the board and `projects_write` can update an item's status

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ypQTqqVy5n8xMPxQSKLMC