### PR TITLE
chore: Pre-approve the github-projects MCP server for all clones

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "enabledMcpjsonServers": ["github-projects"]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with `enabledMcpjsonServers: ["github-projects"]`, pre-approving the MCP server added in #130
- Without this, cloud sessions load the server as "Pending approval" and expose zero tools, because the required one-time interactive trust approval cannot be granted in a non-interactive cloud VM
- Applies to every clone: local Claude Code sessions also skip the approval prompt for this specific named server

## Test Plan

- [ ] After merge: a Claude Code cloud session on this repo shows the `github-projects` server as connected and can run `projects_get` against the psake org project board

## Breaking Changes

None

## Reviewer Note

This pre-approves whatever the `github-projects` entry in `.mcp.json` points at (currently GitHub's official MCP endpoint at `api.githubcopilot.com`, authenticated with each user's own `GH_TOKEN`). Future PRs that modify `.mcp.json` deserve the same review scrutiny as workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ypQTqqVy5n8xMPxQSKLMC