### PR TITLE
chore: Pin Pester 6.0.0 for the repository test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- [**#17**](https://github.com/psake/PowerShellBuild/issues/17) The repository's
+  own test suite now runs on Pester 6.0.0 (pinned in `requirements.psd1`). This
+  is a development-dependency change only — the shipped module's Pester
+  compatibility contract is unchanged: `Test-PSBuildPester` still imports Pester
+  with a 5.0.0 minimum and the manifest still declares Pester 5.x support, so
+  consumers on Pester 5 are unaffected.
+
 ## [0.8.1] 2026-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### Changed
-
-- [**#17**](https://github.com/psake/PowerShellBuild/issues/17) The repository's
-  own test suite now runs on Pester 6.0.0 (pinned in `requirements.psd1`). This
-  is a development-dependency change only — the shipped module's Pester
-  compatibility contract is unchanged: `Test-PSBuildPester` still imports Pester
-  with a 5.0.0 minimum and the manifest still declares Pester 5.x support, so
-  consumers on Pester 5 are unaffected.
-
 ## [0.8.1] 2026-06-03
 
 ### Fixed

--- a/instructions/repository-specific.instructions.md
+++ b/instructions/repository-specific.instructions.md
@@ -284,6 +284,9 @@ don't replace them.
 - **Script analysis**: PSScriptAnalyzer config is `PowerShellBuild/ScriptAnalyzerSettings.psd1`.
   Default severity threshold for build failure is `Error`. Warnings are reported but don't
   fail the build.
+- **Changelog scope**: `CHANGELOG.md` documents user-facing changes to the shipped module
+  only. Repository-internal changes — development dependencies, CI workflows, this repo's own
+  build scripts, or the test suite — do not get changelog entries.
 - **Spell-checker ignores**: inline comments — `# spell-checker:ignore MAML PSGALLERY`.
 
 ## How Consumers Use This Module

--- a/instructions/repository-specific.instructions.md
+++ b/instructions/repository-specific.instructions.md
@@ -234,7 +234,11 @@ versions — and installed via **PSDepend** when `./build.ps1 -Bootstrap` runs:
 
 ## Testing
 
-Tests live in `tests/` and use **Pester 5+** syntax.
+Tests live in `tests/` and run on **Pester 6.0.0** (pinned exactly in `requirements.psd1`;
+see psake/PowerShellBuild#17 for the targeting decision). Write assertions with the classic
+`Should -Be` syntax — valid in both Pester 5 and 6 — rather than the Pester 6-only `Should-*`
+assertion family, so tests remain backportable. The shipped module's own Pester compatibility
+floor (5.0.0 in `Test-PSBuildPester`) is a separate contract and is unchanged.
 
 - Always build the module before running Pester directly — running against source can produce
   incorrect results. Prefer `./build.ps1 -Task Test` over a raw `Invoke-Pester` call.

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -4,7 +4,7 @@
     }
     BuildHelpers     = '2.0.16'
     Pester           = @{
-        Version    = '5.8.0'
+        Version    = '6.0.0'
         Parameters = @{
             SkipPublisherCheck = $true
         }

--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -77,41 +77,50 @@ Describe "Test help for <_.Name>" -ForEach $commands {
         ($commandHelp.Examples.Example.Remarks | Select-Object -First 1).Text | Should -Not -BeNullOrEmpty
     }
 
-    It "Help link <_> is valid" -ForEach $helpLinks {
-        (Invoke-WebRequest -Uri $_ -UseBasicParsing).StatusCode | Should -Be '200'
-    }
-
-    Context "Parameter <_.Name>" -Foreach $commandParameters {
-
-        BeforeAll {
-            $parameter         = $_
-            $parameterName     = $parameter.Name
-            $parameterHelp     = $commandHelp.parameters.parameter | Where-Object Name -eq $parameterName
-            $parameterHelpType = if ($parameterHelp.ParameterValue) { $parameterHelp.ParameterValue.Trim() }
-        }
-
-        # Should be a description for every parameter
-        It "Has description" {
-            $parameterHelp.Description.Text | Should -Not -BeNullOrEmpty
-        }
-
-        # Required value in Help should match IsMandatory property of parameter
-        It "Has correct [mandatory] value" {
-            $codeMandatory = $_.IsMandatory.toString()
-            $parameterHelp.Required | Should -Be $codeMandatory
-        }
-
-        # Parameter type in help should match code
-        It "Has correct parameter type" {
-            $parameterHelpType | Should -Be $parameter.ParameterType.Name
+    # The if guards around the data-driven blocks below skip generation when the
+    # collection is empty. Pester 5 skipped empty -ForEach silently; Pester 6 fails
+    # discovery instead, and these guards keep the v5 behavior on both versions.
+    if ($helpLinks) {
+        It "Help link <_> is valid" -ForEach $helpLinks {
+            (Invoke-WebRequest -Uri $_ -UseBasicParsing).StatusCode | Should -Be '200'
         }
     }
 
-    Context "Test <_> help parameter help for <commandName>" -Foreach $helpParameterNames {
+    if ($commandParameters) {
+        Context "Parameter <_.Name>" -Foreach $commandParameters {
 
-        # Shouldn't find extra parameters in help.
-        It "finds help parameter in code: <_>" {
-            $_ -in $parameterNames | Should -Be $true
+            BeforeAll {
+                $parameter         = $_
+                $parameterName     = $parameter.Name
+                $parameterHelp     = $commandHelp.parameters.parameter | Where-Object Name -eq $parameterName
+                $parameterHelpType = if ($parameterHelp.ParameterValue) { $parameterHelp.ParameterValue.Trim() }
+            }
+
+            # Should be a description for every parameter
+            It "Has description" {
+                $parameterHelp.Description.Text | Should -Not -BeNullOrEmpty
+            }
+
+            # Required value in Help should match IsMandatory property of parameter
+            It "Has correct [mandatory] value" {
+                $codeMandatory = $_.IsMandatory.toString()
+                $parameterHelp.Required | Should -Be $codeMandatory
+            }
+
+            # Parameter type in help should match code
+            It "Has correct parameter type" {
+                $parameterHelpType | Should -Be $parameter.ParameterType.Name
+            }
+        }
+    }
+
+    if ($helpParameterNames) {
+        Context "Test <_> help parameter help for <commandName>" -Foreach $helpParameterNames {
+
+            # Shouldn't find extra parameters in help.
+            It "finds help parameter in code: <_>" {
+                $_ -in $parameterNames | Should -Be $true
+            }
         }
     }
 }

--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -44,6 +44,8 @@ Describe "Test help for <_.Name>" -ForEach $commands {
         $commandParameters     = global:FilterOutCommonParams -Params $command.ParameterSets.Parameters
         $commandParameterNames = $commandParameters.Name
         $helpLinks             = $commandHelp.relatedLinks.navigationLink.uri
+        $helpParameters        = global:FilterOutCommonParams -Params $commandHelp.Parameters.Parameter
+        $helpParameterNames    = $helpParameters.Name
     }
 
     BeforeAll {
@@ -119,7 +121,7 @@ Describe "Test help for <_.Name>" -ForEach $commands {
 
             # Shouldn't find extra parameters in help.
             It "finds help parameter in code: <_>" {
-                $_ -in $parameterNames | Should -Be $true
+                $_ -in $commandParameterNames | Should -Be $true
             }
         }
     }


### PR DESCRIPTION
## Summary

- Move this repository's own test suite from Pester 5.8.0 to 6.0.0, pinned exactly in `requirements.psd1` (the targeting decision and its guardrails are recorded on #17)
- Fix the one Pester 6 incompatibility in the existing suite: Pester 6 fails discovery on an empty `-ForEach` collection instead of silently generating nothing, which killed the whole `tests/Help.tests.ps1` container because `Build-PSBuildMAMLHelp` has no related help links. The three data-driven blocks (help links, command parameters, help parameter names) are now guarded with discovery-time `if` checks that preserve the Pester 5 behavior and remain valid on both versions
- Per review feedback: compute `$helpParameters`/`$helpParameterNames` during discovery so the help-parameter Context actually generates tests (it had never produced any — the variables were only assigned at run time), and fix the undefined `$parameterNames` reference inside it. Reactivating the block added 66 passing assertions
- Update the repository testing instructions to match

This is a development-dependency change only, so there is no changelog entry (changelog is reserved for user-facing changes to the shipped module). The shipped module's Pester compatibility contract is untouched: `Test-PSBuildPester` still imports Pester with a 5.0.0 minimum and the manifest still declares Pester 5.x support.

Noteworthy: before the guard fix, the dead `Help.tests.ps1` container was reported by Pester (`Container failed: 1`) but the build still exited 0 and psake reported success — a live occurrence of the failure-gate gap fixed in #128 (repo build file) and #133 (shipped function).

## Test Plan

- [x] `./build.ps1 -Bootstrap -Task Test` installs Pester 6.0.0 via PSDepend and runs green locally (Linux, PowerShell 7.6): **367 passed, 0 failed, 15 skipped** (Windows-only signing tests), no failed containers
- [x] Before the `Help.tests.ps1` fixes the same run reported 59 passed + 1 failed container, confirming the guards unlocked the per-command help tests rather than skipping them
- [x] CI matrix green (ubuntu / windows pwsh / windows PowerShell 5.1 / macOS): 382 tests, 0 failed

## Breaking Changes

None for module consumers. Contributors running this repo's test suite will get Pester 6.0.0 installed by `./build.ps1 -Bootstrap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011semwa5HU1BUKKL4RoWjKa