### PR TITLE
fix: Fail the build when a Pester run fails for any reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- [**#128**](https://github.com/psake/PowerShellBuild/pull/128)
+- [**#133**](https://github.com/psake/PowerShellBuild/pull/133)
   `Test-PSBuildPester` now fails the build when a Pester run fails for any
   reason, not only when individual tests fail. Previously the function gated
   only on `FailedCount`, so a `BeforeAll`/`AfterAll` that threw or a test file
   that errored during discovery left the count at zero and the build passed
   despite tests never running. The gate now checks the run's aggregate
   `Result` property, which Pester derives from all failure categories.
+  Companion to [#128](https://github.com/psake/PowerShellBuild/pull/128),
+  which fixes the same gap in this repository's own build file.
 
 ## [0.8.1] 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- [**#128**](https://github.com/psake/PowerShellBuild/pull/128)
+  `Test-PSBuildPester` now fails the build when a Pester run fails for any
+  reason, not only when individual tests fail. Previously the function gated
+  only on `FailedCount`, so a `BeforeAll`/`AfterAll` that threw or a test file
+  that errored during discovery left the count at zero and the build passed
+  despite tests never running. The gate now checks the run's aggregate
+  `Result` property, which Pester derives from all failure categories.
+
 ## [0.8.1] 2026-06-03
 
 ### Fixed

--- a/PowerShellBuild/Public/Test-PSBuildPester.ps1
+++ b/PowerShellBuild/Public/Test-PSBuildPester.ps1
@@ -104,7 +104,10 @@ function Test-PSBuildPester {
 
         $testResult = Invoke-Pester -Configuration $configuration -Verbose:$VerbosePreference
 
-        if ($testResult.FailedCount -gt 0) {
+        # Gate on the run's aggregate result rather than FailedCount alone. A failed
+        # BeforeAll/AfterAll or a container that errors during discovery leaves
+        # FailedCount at 0, but Pester still marks the overall Result as 'Failed'.
+        if ($testResult.Result -eq 'Failed') {
             throw $LocalizedData.PesterTestsFailed
         }
 

--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -51,7 +51,9 @@ task Pester -depends Build {
 
     $testResults = Invoke-Pester -Configuration $pesterConfiguration
 
-    if (($testResults.FailedCount + $testResults.FailedBlocksCount + $testResults.FailedContainersCount) -gt 0) {
+    # Result aggregates every failure category (failed tests, blocks, containers),
+    # matching the gate in Test-PSBuildPester.
+    if ($testResults.Result -eq 'Failed') {
         $testResults | Format-List
         Write-Error -Message 'One or more Pester tests failed. Build cannot continue!'
     }


### PR DESCRIPTION
## Summary

- `Test-PSBuildPester` gated pass/fail only on `$testResult.FailedCount`, so a `BeforeAll`/`AfterAll` that threw or a test file that errored during discovery left the count at zero and the build passed despite tests never running
- The gate now checks the run's aggregate `Result` property (`-eq 'Failed'`), which Pester derives from every failure category — failed tests, failed blocks, and failed containers. Using `Result` was suggested by @nohwnd in the #128 discussion
- Follow-up after #128 merged: this repo's own `psakeFile.ps1` Pester gate (the three-counter sum from #128) is switched to the same `Result` check, so both gates share one definition of "failed". Behavior is identical; this half is repo-internal and has no changelog entry

Same bug lineage as #31, #52, and #57.

## Test Plan

Verified against the built module with crash fixtures, under both Pester majors:

- [x] **Pester 5.8.0** (what CI bootstraps): discovery-crash file → build now fails (previously `FailedCount=0`, `Result=Failed`, build passed green); `BeforeAll` crash → build fails; healthy suite → build passes
- [x] **Pester 6.0.0**: same three scenarios, same outcomes
- [x] Repo `psakeFile.ps1` gate verified both directions: a discovery-crash container fails the build (exit 1); a healthy run under Pester 5.8.0 passes (301 tests, exit 0)
- [x] Full repo suite green: 316 tests, 0 failed on the full CI matrix
- [ ] CI green on the final revision (ubuntu / windows pwsh / windows PowerShell 5.1 / macOS)

## Breaking Changes

None in the API. Behavior change by design: builds that previously reported success while a setup block or test container had crashed will now correctly fail. Downstream consumers whose suites have latent setup failures will see red builds — that is the bug being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011semwa5HU1BUKKL4RoWjKa