### PR TITLE
chore: Release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.8.2] 2026-07-08
+
 ### Fixed
 
 - [**#133**](https://github.com/psake/PowerShellBuild/pull/133)

--- a/PowerShellBuild/PowerShellBuild.psd1
+++ b/PowerShellBuild/PowerShellBuild.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PowerShellBuild.psm1'
-    ModuleVersion     = '0.8.1'
+    ModuleVersion     = '0.8.2'
     GUID              = '15431eb8-be2d-4154-b8ad-4cb68a488e3d'
     Author            = 'Brandon Olin'
     CompanyName       = 'Community'


### PR DESCRIPTION
## Summary

- Bump `ModuleVersion` to 0.8.2 and convert the `Unreleased` changelog section to `[0.8.2] 2026-07-08`
- Single user-facing change in this release: the `Test-PSBuildPester` failure-gate fix from #133 — builds now fail when a Pester run fails for any reason (failed setup blocks and discovery errors included), not only when individual tests fail

After this merges, creating the `v0.8.2` GitHub release (notes = the 0.8.2 changelog section) triggers the publish workflow, which pushes 0.8.2 to PSGallery.

## Test Plan

- [x] Full suite green locally: 367 passed, 0 failed, 15 skipped — including the Manifest tests that assert the changelog and manifest versions agree
- [ ] CI matrix green

## Breaking Changes

None. Note for downstream consumers: suites with latent `BeforeAll`/discovery failures that previously passed silently will correctly fail after updating — see the 0.8.2 changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011semwa5HU1BUKKL4RoWjKa

---
_Generated by [Claude Code](https://claude.ai/code/session_011semwa5HU1BUKKL4RoWjKa)_