### PR TITLE
chore: Track code coverage of the built module in the Pester task

### DIFF
--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -49,7 +49,24 @@ task Pester -depends Build {
     $pesterConfiguration.TestResult.OutputPath = $testResultsXml
     $pesterConfiguration.TestResult.OutputFormat = 'NUnitXml'
 
+    # Track (never gate on) code coverage of the built module. The number understates real
+    # coverage: tests that exercise code in child processes (the build.tests.ps1 child builds
+    # and the Test-PSBuildPester subprocess matrix) are invisible to session instrumentation.
+    # Publishing the JaCoCo file from CI is psake/PowerShellBuild#139.
+    $pesterConfiguration.CodeCoverage.Enabled      = $true
+    $pesterConfiguration.CodeCoverage.Path         = $settings.ModuleOutDir
+    $pesterConfiguration.CodeCoverage.OutputPath   = [IO.Path]::Combine($testResultsDir, 'coverage.xml')
+    $pesterConfiguration.CodeCoverage.OutputFormat = 'JaCoCo'
+
     $testResults = Invoke-Pester -Configuration $pesterConfiguration
+
+    if ($testResults.CodeCoverage) {
+        $coverageMessage = 'Code coverage: {0:p1} of analyzed commands executed ({1} of {2})' -f (
+            $testResults.CodeCoverage.CoveragePercent / 100),
+            $testResults.CodeCoverage.CommandsExecutedCount,
+            $testResults.CodeCoverage.CommandsAnalyzedCount
+        Write-Host $coverageMessage -ForegroundColor Cyan
+    }
 
     # Result aggregates every failure category (failed tests, blocks, containers),
     # matching the gate in Test-PSBuildPester.

--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -61,10 +61,11 @@ task Pester -depends Build {
     $testResults = Invoke-Pester -Configuration $pesterConfiguration
 
     if ($testResults.CodeCoverage) {
-        $coverageMessage = 'Code coverage: {0:p1} of analyzed commands executed ({1} of {2})' -f (
-            $testResults.CodeCoverage.CoveragePercent / 100),
-            $testResults.CodeCoverage.CommandsExecutedCount,
+        $coverageMessage = 'Code coverage: {0:p1} of analyzed commands executed ({1} of {2})' -f @(
+            ($testResults.CodeCoverage.CoveragePercent / 100)
+            $testResults.CodeCoverage.CommandsExecutedCount
             $testResults.CodeCoverage.CommandsAnalyzedCount
+        )
         Write-Host $coverageMessage -ForegroundColor Cyan
     }
 


### PR DESCRIPTION
## Summary

- Enable Pester code coverage over the built module output in the repository's own Pester task (Pester 6's profiler-based tracer, so the runtime cost is small)
- Write a JaCoCo report to `tests/out/coverage.xml` and print a one-line summary in the task output, so the coverage number is visible in every CI log
- **Tracking only — deliberately no threshold gate.** The number understates real coverage: tests that exercise code in child processes (the `build.tests.ps1` child builds and the `Test-PSBuildPester` subprocess matrix from #137) are invisible to session instrumentation. It's a trend line for the #17 test batch, not an absolute
- Publishing the JaCoCo file from CI requires a change to the shared `psake/.github` workflow — tracked separately as #139. The threshold-math bug in the shipped `Test-PSBuildPester` coverage feature, found while evaluating this, is #138

No changelog entry: repository-internal change only.

## Test Plan

- [x] `./build.ps1 -Task Test` locally: 391 passed, 0 failed; summary line prints (`Code coverage: 4.2 % of analyzed commands executed (44 of 1044)`) and `tests/out/coverage.xml` is produced (valid JaCoCo)
- [ ] CI matrix green; coverage line visible in each leg's log

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011semwa5HU1BUKKL4RoWjKa

---
_Generated by [Claude Code](https://claude.ai/code/session_011semwa5HU1BUKKL4RoWjKa)_