### PR TITLE
chore: Update InvokeBuild to 5.14.23 and actions/checkout to v4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Publish
         shell: pwsh
         run: |

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -11,6 +11,6 @@
     }
     psake            = '4.9.0'
     PSScriptAnalyzer = '1.25.0'
-    InvokeBuild      = '5.8.1'
+    InvokeBuild      = '5.14.23'
     platyPS          = '0.14.2'
 }


### PR DESCRIPTION
## Description

- `requirements.psd1`: `InvokeBuild` build dependency bumped 5.8.1 → 5.14.23 (latest on PSGallery, verified today)
- `.github/workflows/publish.yaml`: `actions/checkout` bumped v2 → v4

## Related Issue

Phase 1 of #120 — "Refresh non-breaking dependency versions": the `InvokeBuild` and `actions/checkout` items.

## Motivation and Context

Both are the last remaining non-breaking dependency refreshes in Phase 1 (psake and platyPS are deferred to Phase 2 as breaking upgrades). The checkout v2 action runs on a deprecated Node runtime; v4 is the current supported line.

## How Has This Been Tested?

- Full repo suite (`./build.ps1 -Task Test -Bootstrap`) run locally with InvokeBuild 5.14.23 installed — the `IBTasks.tests.ps1` file exercises the Invoke-Build task surface against the new version
- The publish workflow change is exercised on the next release publish; checkout v4 is a drop-in for this job (single checkout step, no parameters)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation (repo-internal: build dependency + CI only; no changelog entry per repo convention)
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my changes (covered by existing `IBTasks.tests.ps1`)
- [x] All new and existing tests passed

## Breaking Changes

None — repo-internal only. Consumer-facing `RequiredModules` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxrhSpD47TSrS9hEJpDMaH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxrhSpD47TSrS9hEJpDMaH)_