### PR TITLE
chore: Register Matt Pocock skills plugin for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,14 @@
 {
-  "enabledMcpjsonServers": ["github-projects"]
+  "enabledMcpjsonServers": ["github-projects"],
+  "extraKnownMarketplaces": {
+    "mattpocock": {
+      "source": {
+        "source": "github",
+        "repo": "mattpocock/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "mattpocock-skills@mattpocock": true
+  }
 }


### PR DESCRIPTION
## Summary

- Registers the `mattpocock/skills` GitHub marketplace in `.claude/settings.json` and enables its
  `mattpocock-skills` plugin, so agents working in this repo pick up the skills automatically
- Adds skills the bundled set does not cover — `implement`, `to-spec`, `to-tickets`, `triage`,
  `wayfinder`, `handoff`, `improve-codebase-architecture`, `grill-with-docs`, `writing-great-skills`
- Repo tooling only: no module source, build script, test, or workflow changes, so no `CHANGELOG.md`
  entry per the changelog scope in `instructions/repository-specific.instructions.md`

## Test Plan

- [ ] `jq . .claude/settings.json` parses (verified locally)
- [ ] Plugin id and marketplace name match `mattpocock/skills` `.claude-plugin/marketplace.json`
      (marketplace `mattpocock`, plugin `mattpocock-skills` — verified against the upstream manifest)
- [ ] On the next Claude Code session in this repo, accept the marketplace trust prompt and confirm
      `/plugin` lists `mattpocock-skills@mattpocock` as installed
- [ ] CI (`test.yml`) stays green — the change does not touch anything the build consumes

## Notes for reviewers

Several of these skills — `tdd`, `code-review`, `codebase-design`, `domain-modeling`,
`diagnosing-bugs`, `grilling`, `prototype`, `research`, `resolving-merge-conflicts` — already ship
with Claude Code, so those names will appear twice in the skill list (plugin ones are namespaced).
Individual duplicates can be silenced later with `skillOverrides` if the noise is a problem.

This is the checked-in project settings file, so every contributor using Claude Code in this repo
gets the trust prompt on their next session. If we would rather keep it opt-in per person, the same
two blocks belong in `.claude/settings.local.json` instead.

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoWFUBzYD3M9wbDAxFKbcD
