### PR TITLE
fix: Retry the analyzer in the Analyze task

### DIFF
--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -16,7 +16,29 @@ task Init {
 task Test -Depends Init, Analyze, Pester -description 'Run test suite'
 
 task Analyze -depends Build {
-    $analysis = Invoke-ScriptAnalyzer -Path $settings.ModuleOutDir -Recurse -Verbose:$false -Settings ([IO.Path]::Combine($env:BHModulePath, 'ScriptAnalyzerSettings.psd1'))
+    # PSScriptAnalyzer crashes intermittently on an internal race of its own, unrelated to the
+    # code being analyzed, and a re-run always succeeds. See psake/PowerShellBuild#136.
+    $analyzerParameters = @{
+        Path        = $settings.ModuleOutDir
+        Recurse     = $true
+        Verbose     = $false
+        Settings    = [IO.Path]::Combine($env:BHModulePath, 'ScriptAnalyzerSettings.psd1')
+        ErrorAction = 'Stop'
+    }
+    $maximumAttempt = 3
+    for ($attempt = 1; $attempt -le $maximumAttempt; $attempt++) {
+        try {
+            $analysis = Invoke-ScriptAnalyzer @analyzerParameters
+            break
+        } catch {
+            if ($attempt -eq $maximumAttempt) {
+                throw
+            }
+            Write-Warning "PSScriptAnalyzer failed on attempt $attempt of $maximumAttempt. Retrying."
+            Start-Sleep -Seconds 2
+        }
+    }
+
     $errors   = $analysis | Where-Object {$_.Severity -eq 'Error'}
     $warnings = $analysis | Where-Object {$_.Severity -eq 'Warning'}
     if (@($errors).Count -gt 0) {

--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -31,10 +31,14 @@ task Analyze -depends Build {
             $analysis = Invoke-ScriptAnalyzer @analyzerParameters
             break
         } catch {
+            $errorRecord = $_
             if ($attempt -eq $maximumAttempt) {
-                throw
+                throw $errorRecord
             }
-            Write-Warning "PSScriptAnalyzer failed on attempt $attempt of $maximumAttempt. Retrying."
+            Write-Warning (
+                "PSScriptAnalyzer failed on attempt $attempt of $maximumAttempt and will be retried. " +
+                "[$($errorRecord.FullyQualifiedErrorId)] $($errorRecord.Exception.Message)"
+            )
             Start-Sleep -Seconds 2
         }
     }


### PR DESCRIPTION
## Summary

- Retry the `Invoke-ScriptAnalyzer` call in the `Analyze` task up to three times, rethrowing on the last attempt, so the intermittent PSScriptAnalyzer crash tracked in #136 no longer fails the build
- Pass `-ErrorAction Stop` explicitly rather than relying on `build.ps1` setting `$ErrorActionPreference` process-wide, so the `try`/`catch` does not depend on an ambient caller preference

The crash is a thread-safety defect inside PSScriptAnalyzer, which runs its script rules in parallel against a process-wide unsynchronised singleton. It has no relationship to the code being analyzed, which is why re-running the job always succeeded. Full root cause analysis, reproduction, and upstream links are in [this comment on #136](https://github.com/psake/PowerShellBuild/issues/136#issuecomment-5160655044).

The retry is deliberately unconditional rather than matched against the known crash signatures. Those signatures are symptoms of an upstream race rather than a fixed contract — four distinct exception types appeared during the analysis — so matching on them would let a new variant bypass the mitigation. The cost is that a genuine analyzer failure takes three attempts before failing, which is a few seconds on a path already headed for red.

## Test Plan

- [x] `./build.ps1 -Task Test` passes (422 passed, 0 failed, 15 skipped)
- [x] Validated against a reproduction of the race: 45 runs of the real `Analyze` task, zero build failures, with the crash occurring and being absorbed
- [x] Confirmed a non-transient failure still fails the build, since the final attempt rethrows
- [ ] CI green across the `ubuntu-latest` / `windows-latest` / `macOS-latest` matrix

## Breaking Changes

None. This changes only this repository's own build, not the shipped module.

## Notes

- `Test-PSBuildScriptAnalysis` in the shipped module is exposed to the same race but behaves differently, since it calls `Invoke-ScriptAnalyzer` without `-ErrorAction Stop` and so does not fail. Tracked separately in #147 and deliberately out of scope here.
- No `CHANGELOG.md` entry, per the changelog scope rule in `instructions/repository-specific.instructions.md`: the changelog covers user-facing changes to the shipped module, and this touches only this repository's own build script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2tE5nDWYPfmyWP2yPeWXT


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2tE5nDWYPfmyWP2yPeWXT)_